### PR TITLE
Resolve #5

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -151,6 +151,9 @@ class _BuildStep(_MavenStep):
 class _GitHubReleaseStep(_MavenStep):
     def execute(self):
         _logger.debug('Maven GitHub release step')
+        if self.assembly.isStable():
+            _logger.debug("Stable releases don't automatically push a snapshot tag to GitHub")
+            return
 
         token = self.getToken()
         if not token:

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -81,6 +81,11 @@ class _GitHubReleaseStep(_PythonStep):
     '''A step that releases software to GitHub
     '''
     def execute(self):
+        _logger.debug('Python GitHub release step')
+        if self.assembly.isStable():
+            _logger.debug("Stable releases don't automatically push a snapshot tag to GitHub")
+            return
+
         token = self.getToken()
         if not token:
             _logger.info('🤷‍♀️ No GitHub administrative token; cannot release to GitHub')


### PR DESCRIPTION
## 📜 Summary

Merge this (if you dare) and it just might resolve #5 for Python- and Maven-based roundups.

## 🩺 Test Data and/or Report

The Roundup action doesn't yet have unit, functional, integration, or acceptance tests. Or tests of any kind. Maybe it should! It'd require developing only about 10,000 stubs.

## 👪 Related Issues

- #5 