### PR TITLE
Resolve #9: snapshot artifacts

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -185,7 +185,6 @@ class _ArtifactPublicationStep(_MavenStep):
             invokeGIT(['git', 'tag', 'v' + version])
             invokeGIT(['git', 'push', '--tags'])
         else:
-            version = self.getVersionFromPOM()
             self.invokeMaven(['clean', 'site', 'deploy'])
 
 

--- a/src/pds/roundup/assembly.py
+++ b/src/pds/roundup/assembly.py
@@ -61,8 +61,8 @@ class PDSAssembly(Assembly):
         StepName.requirements,
         StepName.docs,
         StepName.build,
-        StepName.githubRelease,
         StepName.artifactPublication,
+        StepName.githubRelease,
         StepName.docPublication,
     ]
 


### PR DESCRIPTION
## 📜 Summary

Merge this (if you dare) and potentially resolve #9. What this does essentially is put the `githubRelease` step after the `artifactPublication` step.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- #9 