### PR TITLE
Resolve #11

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -161,10 +161,12 @@ class _GitHubReleaseStep(_MavenStep):
             return
 
         # 😮 TODO: Use Python GitHub API!
-        # 🤷‍♀️ Thomas uses ``--unshallow``, but when I try that I get an error.
-        # So we skip it for now:
-        invokeGIT(['fetch', '--prune', '--tags'])
-        tags = invokeGIT(['tag', '--list', '*dev*'])
+
+        try:
+            invokeGIT(['fetch', '--prune', '--unshallow', '--tags'])
+        except Exception:
+            invokeGIT(['fetch', '--prune', '--tags'])
+        tags = invokeGIT(['tag', '--list', '*SNAPSHOT*'])
         for tag in tags:
             tag = tag.strip()
             try:

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -93,11 +93,10 @@ class _GitHubReleaseStep(_PythonStep):
 
         # 😮 TODO: Use Python GitHub API
 
-        # ❓ Thomas uses ``--unshallow``, but when I try that I get an error:
-        #    fatal: --unshallow on a complete repository does not make sense
-        # invokeGIT(['fetch', '--prune', '--unshallow', '--tags'])
-        # So I just won't use it:
-        invokeGIT(['fetch', '--prune', '--tags'])
+        try:
+            invokeGIT(['fetch', '--prune', '--unshallow', '--tags'])
+        except Exception:
+            invokeGIT(['fetch', '--prune', '--tags'])
         tags = invokeGIT(['tag', '--list', '*dev*'])
         for tag in tags:
             tag = tag.strip()


### PR DESCRIPTION
## 📜 Summary

Fix #11 by looking for `*SNAPSHOT*` in Maven-based roundups instead of `*dev*`.

Also, we try to do an `--unshallow` prune with tags and if it fails, then just a plain prune with tags. Mmmm. Prunes. 🤤

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- #11 