### PR TITLE
Resolve #13 by including both stdout and stderr

### DIFF
--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -41,7 +41,8 @@ def invoke(argv):
         return cp.stdout.decode('utf-8')
     except subprocess.CalledProcessError as ex:
         _logger.critical('💥 Process with command line %r failed with status %d', argv, ex.returncode)
-        _logger.critical('📚 Stderr = «%s»', ex.stderr)
+        _logger.critical('🪵 Stdout = «%s»', ex.stdout.decode('utf-8'))
+        _logger.critical('📚 Stderr = «%s»', ex.stderr.decode('utf-8'))
         raise InvokedProcessError(ex)
 
 


### PR DESCRIPTION
## 📜 Summary

Fix #13 by including the standard output as well. Previously we just included the standard error. Philosophically, you could argue that should be sufficient for a failed process. Anyway, as icing on the cake, we also change the outputs and errors from byte strings into UTF-8 character stirngs.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- #13 
