### PR TITLE
Resolve #11 Part II: The Taggening

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -164,16 +164,24 @@ class _GitHubReleaseStep(_MavenStep):
 
         try:
             invokeGIT(['fetch', '--prune', '--unshallow', '--tags'])
-        except Exception:
+        except InvokedProcessError:
+            _logger.info('🤔 Unshallow prune fetch tags failed, so trying without unshallow')
             invokeGIT(['fetch', '--prune', '--tags'])
-        tags = invokeGIT(['tag', '--list', '*SNAPSHOT*'])
+        tags = invokeGIT(['tag', '--list', '*SNAPSHOT*']).split('\n')
         for tag in tags:
             tag = tag.strip()
+            if not tag: continue
             try:
+                _logger.debug('␡ Attempting to delete tag %s', tag)
                 invokeGIT(['tag', '--delete', tag])
                 invokeGIT(['push', '--delete', 'origin', tag])
-            except InvokedProcessError:
-                pass
+            except InvokedProcessError as ex:
+                _logger.info(
+                    '🧐 Cannot delete tag %s, stdout=«%s», stderr=«%s»; but pressing on',
+                    tag,
+                    ex.error.stdout.decode('utf-8'),
+                    ex.error.stderr.decode('utf-8'),
+                )
         invoke(['maven-snapshot-release', '--token', token])
 
 

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -37,11 +37,12 @@ def invoke(argv):
     _logger.debug('🏃‍♀️ Running «%r»', argv)
     try:
         cp = subprocess.run(argv, stdin=subprocess.DEVNULL, capture_output=True, check=True)
-        _logger.debug('🏁 Run complete, rc=%d, output=%s', cp.returncode, cp.stdout)
+        _logger.debug('🏁 Run complete, rc=%d, output=«%s»', cp.returncode, cp.stdout.decode('utf-8'))
         return cp.stdout.decode('utf-8')
     except subprocess.CalledProcessError as ex:
         _logger.critical('💥 Process with command line %r failed with status %d', argv, ex.returncode)
-        _logger.critical('📚 Stderr = «%s»', ex.stderr)
+        _logger.critical('🪵 Stdout = «%s»', ex.stdout.decode('utf-8'))
+        _logger.critical('📚 Stderr = «%s»', ex.stderr.decode('utf-8'))
         raise InvokedProcessError(ex)
 
 


### PR DESCRIPTION
## 📜 Summary

Fix #11 a second time; running `git tag --list PATTERN` yields a single string, not a list; we tokenize the string on `\n`.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- #11 