### PR TITLE
Resolve #14 (re-opened) by adding letter `s`

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
     - '--assembly'
     - ${{inputs.assembly}}
     - '--packages'
-    - ${{input.packages}}
+    - ${{inputs.packages}}
     - '--debug'
 
 ...


### PR DESCRIPTION
## 📜 Summary

Fix #14 again by adding a missing letter `s`.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- Issue #14
- PR #17 