### PR TITLE
remove tag creation command in maven stable, typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Make a local image for testing:
 
     docker image build --tag pds-roundup:latest .
 
-You can then poke aorund in it:
+You can then poke around in it:
 
     docker container run --interactive --tty --rm --name roundup --volume ${PWD}:/mnt --entrypoint /bin/sh pds-roundup:latest
 
@@ -171,6 +171,7 @@ For reasons I can't fathom, the Python environment used to bootstrap the [buildo
 
 ```console
 python3 -m venv /tmp/huh
+source /tmp/huh/bin/activate
 /tmp/huh/bin/pip install github3.py
 /tmp/huh/bin/python3 bootstrap.py --setuptools-version=50.3.0
 bin/buildout

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -192,8 +192,10 @@ class _ArtifactPublicationStep(_MavenStep):
             invokeGIT(['add', 'pom.xml'])
             version = self.getVersionFromPOM()
             self.invokeMaven(['--activate-profiles', 'release', 'clean', 'package', 'site', 'deploy'])
-            invokeGIT(['git', 'tag', 'v' + version])
-            invokeGIT(['git', 'push', '--tags'])
+            # it does not look like we need that
+            # + invokeGIT does not need to repeat 'git' argument
+            #invokeGIT(['git', 'tag', 'v' + version])
+            #invokeGIT(['git', 'push', '--tags'])
         else:
             self.invokeMaven(['clean', 'site', 'deploy'])
 


### PR DESCRIPTION
See bug #21 

My question for review is how is it reasonable to test that.

I need also a confirmation that the tag is supposed to be created outside the roundup action and triggers the action.