### PR TITLE
Add compile to mvn site step

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -139,7 +139,7 @@ class _IntegrationTestStep(_MavenStep):
 class _DocsStep(_MavenStep):
     def execute(self):
         _logger.debug('Maven docs step')
-        self.invokeMaven(['site'])
+        self.invokeMaven(['compile', 'site'])
 
 
 class _BuildStep(_MavenStep):


### PR DESCRIPTION
Some java projects require compilation in order to build the site when they have multiple apps / cross dependencies. See pds4-information-model.

There may be a way to do this in the POM, but couldn't track down a solution, and this just adds some time to the build.