### PR TITLE
Resolve #23 with way to override Maven phases/goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ This is an [action for GitHub](https://github.com/features/actions) that does a 
 To use this action in your own workflow, just provide it `with` any of the following parameters:
 
 -   `assembly` — Tells what kind if roundup we're doing, such as `stable` (production); defaults to `unstable` or "development" releases.
--   `packages` — A comma-separated list of extra packages needed to complete your assembly.
+-   `packages` — A comma-separated list of extra packages (see "Environment", below) needed to complete your assembly.
+
+For Maven-based roundups *only*, you can also specify these optional `with` parameters:
+
+-   `maven-test-phases` — A comma-separated list of Maven phases for testing, defaults to `test`
+-   `maven-doc-phases` — A comma-separated list of Maven phases for documentation generation, defaults to `package,site`
+-   `maven-build-phases` — A comma-separated list of Maven phases for building the software, defaults to `compile`
+-   `maven-stable-artifact-phases` — A comma-separated list of Maven phases for stable artifact publication, defaults to `clean,package,site,deploy`
+-   `maven-unstable-artifact-phases` — A comma-separated list of Maven phases for unstable artifact publication, defaults to `clean,site,deploy`
 
 Depending on the roundup, you may also need the following environment variables:
 
@@ -36,7 +44,7 @@ This causes the Roundup to use OpenJDK 11 and also installs the `pdfgrep` packag
 
 #### ☕️ Java Note
 
-If you install an JK older than OpenJDK 1.8.0_252, you may need to also set the `JAVA_HOME` environemnt variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
+If you install an JDK older than OpenJDK 1.8.0_252, you may need to also set the `JAVA_HOME` environemnt variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
 
 
 ### 👮‍♂️ GitHub Admin Token

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use this action in your own workflow, just provide it `with` any of the follo
 For Maven-based roundups *only*, you can also specify these optional `with` parameters:
 
 -   `maven-test-phases` — A comma-separated list of Maven phases for testing, defaults to `test`
--   `maven-doc-phases` — A comma-separated list of Maven phases for documentation generation, defaults to `package,site`
+-   `maven-doc-phases` — A comma-separated list of Maven phases for documentation generation, defaults to `package,site,site:stage`
 -   `maven-build-phases` — A comma-separated list of Maven phases for building the software, defaults to `compile`
 -   `maven-stable-artifact-phases` — A comma-separated list of Maven phases for stable artifact publication, defaults to `clean,package,site,deploy`
 -   `maven-unstable-artifact-phases` — A comma-separated list of Maven phases for unstable artifact publication, defaults to `clean,site,deploy`

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,26 @@ inputs:
             commas to separate each. These are Alpine Linux package names.
         required: false
         default: ''
+    maven-test-phases:
+        description: 🩺 Maven phases (or goals) to invoke for running tests.
+        required: false
+        default: 'test'
+    maven-doc-phases:
+        description: 📚 Maven phases (or goals) to invoke for generation documentation.
+        required: false
+        default: 'package,site'
+    maven-build-phases:
+        description: 👷‍ Maven phases (or goals) to invoke for building software.
+        required: false
+        default: 'compile'
+    maven-stable-artifact-phases:
+        description: 😌 Maven phases (or goals) to invoke for publishing stable artifacts.
+        required: false
+        default: 'clean,package,site,deploy'
+    maven-unstable-artifact-phases:
+        description: 🤪 Maven phases (or goals) to invoke for publishing unstable artifacts.
+        required: false
+        default: 'clean,site,deploy'
 runs:
     using: 'docker'
     image: 'Dockerfile'
@@ -33,6 +53,16 @@ runs:
         - ${{inputs.assembly}}
         - '--packages'
         - ${{inputs.packages}}
+        - '--maven-test-phases'
+        - ${{inputs.maven-test-phasese}}
+        - '--maven-doc-phases'
+        - ${{inputs.maven-doc-phases}}
+        - '--maven-build-phases'
+        - ${{inputs.maven-build-phases}}
+        - '--maven-stable-artifact-phases'
+        - ${{inputs.maven-stable-artifact-phases}}
+        - '--maven-unstable-artifact-phases'
+        - ${{inputs.maven-unstable-artifact-phases}}
         - '--debug'
 
 ...

--- a/action.yaml
+++ b/action.yaml
@@ -10,29 +10,29 @@
 name: '🤠 PDS Engineering: Roundup'
 author: 'Sean Kelly <kelly@seankelly.biz>'
 branding:
-  icon: 'circle'
-  color: 'orange'
+    icon: 'circle'
+    color: 'orange'
 inputs:
-  assembly:
-    description: >
-      🤠 What kind of roundup are we doing, such as `stable` or `unstable` or
-      something else? We default to `unstable`.
-    required: false
-    default: 'unstable'
-  packages:
-    description: >
-      📦 What packages should be installed prior to starting the roundup? Use
-      commas to separate each. These are Alpine Linux package names.
-    required: false
-    default: ''
+    assembly:
+        description: >
+            🤠 What kind of roundup are we doing, such as `stable` or `unstable` or
+            something else? We default to `unstable`.
+        required: false
+        default: 'unstable'
+    packages:
+        description: >
+            📦 What packages should be installed prior to starting the roundup? Use
+            commas to separate each. These are Alpine Linux package names.
+        required: false
+        default: ''
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - '--assembly'
-    - ${{inputs.assembly}}
-    - '--packages'
-    - ${{inputs.packages}}
-    - '--debug'
+    using: 'docker'
+    image: 'Dockerfile'
+    args:
+        - '--assembly'
+        - ${{inputs.assembly}}
+        - '--packages'
+        - ${{inputs.packages}}
+        - '--debug'
 
 ...

--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ inputs:
     maven-doc-phases:
         description: 📚 Maven phases (or goals) to invoke for generation documentation.
         required: false
-        default: 'package,site'
+        default: 'package,site,site:stage'
     maven-build-phases:
         description: 👷‍ Maven phases (or goals) to invoke for building software.
         required: false

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -19,7 +19,7 @@ _mavenXSDLocation = 'https://maven.apache.org/xsd/settings-1.0.0.xsd'
 
 class MavenContext(Context):
     '''A Maven context supports Maven (Java) software proejcts'''
-    def __init__(self, cwd, environ):
+    def __init__(self, cwd, environ, args):
         self.steps = {
             StepName.null:                NullStep,
             StepName.unitTest:            _UnitTestStep,
@@ -32,7 +32,7 @@ class MavenContext(Context):
             StepName.artifactPublication: _ArtifactPublicationStep,
             StepName.docPublication:      _DocPublicationStep,
         }
-        super(MavenContext, self).__init__(cwd, environ)
+        super(MavenContext, self).__init__(cwd, environ, args)
 
 
 class _MavenStep(Step):
@@ -128,7 +128,7 @@ class _MavenStep(Step):
 class _UnitTestStep(_MavenStep):
     def execute(self):
         _logger.debug('Maven unit test step')
-        self.invokeMaven(['test'])
+        self.invokeMaven(self.assembly.context.args.maven_test_phases.split(','))
 
 
 class _IntegrationTestStep(_MavenStep):
@@ -139,13 +139,13 @@ class _IntegrationTestStep(_MavenStep):
 class _DocsStep(_MavenStep):
     def execute(self):
         _logger.debug('Maven docs step')
-        self.invokeMaven(['package', 'site'])
+        self.invokeMaven(self.assembly.context.args.maven_doc_phases.split(','))
 
 
 class _BuildStep(_MavenStep):
     def execute(self):
         _logger.debug('Maven build step')
-        self.invokeMaven(['compile'])
+        self.invokeMaven(self.assembly.context.args.maven_build_phases.split(','))
 
 
 class _GitHubReleaseStep(_MavenStep):
@@ -190,14 +190,11 @@ class _ArtifactPublicationStep(_MavenStep):
         if self.assembly.isStable():
             self.invokeMaven(['-DremoveSnapshot=true', 'versions:set'])
             invokeGIT(['add', 'pom.xml'])
-            version = self.getVersionFromPOM()
-            self.invokeMaven(['--activate-profiles', 'release', 'clean', 'package', 'site', 'deploy'])
-            # it does not look like we need that
-            # + invokeGIT does not need to repeat 'git' argument
-            #invokeGIT(['git', 'tag', 'v' + version])
-            #invokeGIT(['git', 'push', '--tags'])
+            args = ['--activate-profiles', 'release']
+            args.extend(self.assembly.context.args.maven_stable_artifact_phases.split(','))
+            self.invokeMaven(args)
         else:
-            self.invokeMaven(['clean', 'site', 'deploy'])
+            self.invokeMaven(self.assembly.context.args.maven_unstable_artifact_phases.split(','))
 
 
 class _DocPublicationStep(DocPublicationStep):  # Could multiply inherit from _MavenStep too for semantics

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -14,7 +14,7 @@ _logger = logging.getLogger(__name__)
 
 class PythonContext(Context):
     '''A Python context supports Python software proejcts'''
-    def __init__(self, cwd, environ):
+    def __init__(self, cwd, environ, args):
         self.steps = {
             StepName.null:                NullStep,
             StepName.unitTest:            _UnitTestStep,
@@ -27,7 +27,7 @@ class PythonContext(Context):
             StepName.artifactPublication: _ArtifactPublicationStep,
             StepName.docPublication:      _DocPublicationStep,
         }
-        super(PythonContext, self).__init__(cwd, environ)
+        super(PythonContext, self).__init__(cwd, environ, args)
 
 
 class _PythonStep(Step):

--- a/src/pds/roundup/context.py
+++ b/src/pds/roundup/context.py
@@ -14,9 +14,9 @@ class Context(object):
     N.B.: So far, ``objects`` was predicted to be a replacement for ``::set-env``
     in a GitHub workflow but I currently have zero use for it.
     '''
-    def __init__(self, cwd, environ):
+    def __init__(self, cwd, environ, args):
         '''Don't call this directly; instead use the ``create`` method'''
-        self.cwd, self.environ, self.objects = cwd, environ, {}
+        self.cwd, self.environ, self.objects, self.args = cwd, environ, {}, args
 
     def __repr__(self):
         return f'<{self.__class__.__name__}(cwd={self.cwd},environ=({len(self.environ)} items))>'
@@ -29,13 +29,13 @@ class Context(object):
         return stepFactory(assembly) if stepFactory else None
 
     @staticmethod
-    def create(cwd, environ):
+    def create(cwd, environ, args):
         '''Create a new context for given current working directory, ``cwd``, and the given
-        ``environ``ment variables.
+        ``environ``ment variables, and the parsed command-line ``args``.
         '''
         from . import contextFactories
         factories, factory = contextFactories(), None
         for entry in os.listdir(cwd):
             factory = factories.get(entry)
             if factory: break
-        return factory(cwd, environ) if factory else None
+        return factory(cwd, environ, args) if factory else None

--- a/src/pds/roundup/main.py
+++ b/src/pds/roundup/main.py
@@ -34,7 +34,7 @@ def _parseArgs():
     # Maven 😩
     group = parser.add_argument_group('Maven phases (or goals), comma-separated')
     group.add_argument('--maven-test-phases', help='🩺 Test (%(default)s)', default='test')
-    group.add_argument('--maven-doc-phases', help='📚 Documentation (%(default)s)', default='package,site')
+    group.add_argument('--maven-doc-phases', help='📚 Documentation (%(default)s)', default='package,site,site:stage')
     group.add_argument('--maven-build-phases', help='👷‍ Build (%(default)s)', default='compile')
     group.add_argument(
         '--maven-stable-artifact-phases',

--- a/src/pds/roundup/main.py
+++ b/src/pds/roundup/main.py
@@ -31,6 +31,21 @@ def _parseArgs():
         help='📦 Additional pacakges (separated with a comma) to install prior to assembly'
     )
 
+    # Maven 😩
+    group = parser.add_argument_group('Maven phases (or goals), comma-separated')
+    group.add_argument('--maven-test-phases', help='🩺 Test (%(default)s)', default='test')
+    group.add_argument('--maven-doc-phases', help='📚 Documentation (%(default)s)', default='package,site')
+    group.add_argument('--maven-build-phases', help='👷‍ Build (%(default)s)', default='compile')
+    group.add_argument(
+        '--maven-stable-artifact-phases',
+        help='😌 Stable artifacts (%(default)s)', default='clean,package,site,deploy'
+    )
+    group.add_argument(
+        '--maven-unstable-artifact-phases',
+        help='🤪 Unstable artifacts (%(default)s)',
+        default='clean,site,deploy'
+    )
+
     # Handle logging
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -48,7 +63,7 @@ def main():
     '''Main entrypoint'''
     args = _parseArgs()
     logging.basicConfig(level=args.loglevel)
-    context = Context.create(os.getcwd(), populateEnvVars(os.environ))
+    context = Context.create(os.getcwd(), populateEnvVars(os.environ), args)
 
     # Bonus package time
     if args.packages:


### PR DESCRIPTION
## 📜 Summary

Fix #23 so that you can override the phases and/or goals the Roundup uses when invoking Maven at various points.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

## 🧩 Related Issues

- #23
