### PR TITLE
Resolve NASA-PDS/roundup-action#32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 __pycache__/
 *.py[cod]
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ For reasons I can't fathom, the Python environment used to bootstrap the [buildo
 ```console
 python3 -m venv /tmp/huh
 source /tmp/huh/bin/activate
-/tmp/huh/bin/pip install github3.py
+/tmp/huh/bin/pip install github3.py rstcloth==0.3.1
 /tmp/huh/bin/python3 bootstrap.py --setuptools-version=50.3.0
 bin/buildout
 ```
+
+(Also need rstcloth==0.3.1 in it. Whatever. I am sick to death of buildout.)
 
 You can then:
 

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -3,9 +3,16 @@
 '''🤠 PDS Roundup — Utilities'''
 
 from .errors import InvokedProcessError
-import subprocess, logging
+import subprocess, logging, re
 
 _logger = logging.getLogger(__name__)
+
+
+# Constants
+# =========
+
+BRANCH_RE = re.compile(r'^release/(\d+)\.(\d+)(\.(\d+))?')
+VERSION_RE = re.compile(r'^v(\d+)\.(\d+)\.(\d+)')
 
 
 # Functions


### PR DESCRIPTION
## 📜 Summary

Implement #32 for Python (only) repositories with automatic tagging of `release/X.Y[.z]` branches based on full version specifications in the branch name or via discovered tags for `X.Y` only branches, and only  for _stable_ roundups.

⚠️ Note that the driving event for these stable roundups should no longer be `on: push: tags: 'v[0-9]+.[0-9]+.[0-9]+'` but can be just `main` (`master`) assuming we make `dev` the default branch for repositories or for `on: push: branch: release/*` otherwise.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, OSSRH stub, PyPI stub, etc.).

##  🧩Related Issues

- #32 
