### PR TITLE
prune dev tag only when release is unstable, update push command

### DIFF
--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -156,9 +156,13 @@ class _GitHubReleaseStep(_PythonStep):
         if not token:
             _logger.info('🤷‍♀️ No GitHub administrative token; cannot release to GitHub')
             return
-        self._pruneDev()
+
+        if not self.assembly.isStable():
+            self._pruneDev()
+
         if self.assembly.isStable():
             self._tagRelease()
+
         invoke(['python-snapshot-release', '--token', token])  # Equivalent to ``python-release``
 
 

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -99,5 +99,5 @@ def commit(filename, message):
     invokeGIT(['pull', 'origin', 'master'])
     invokeGIT(['add', filename])
     invokeGIT(['commit', '--allow-empty', '--message', message])
-    invokeGIT(['push'])
+    invokeGIT(['push origin HEAD:master'])
 


### PR DESCRIPTION
**Summary***
I change the push request which failed with message:
CRITICAL:pds.roundup.util:💥 Process with command line ['git', 'push'] failed with status 128
CRITICAL:pds.roundup.util:🪵 Stdout = «»
CRITICAL:pds.roundup.util:📚 Stderr = «fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>


I also changed the python release step to only prune dev releases when we do an unstable release (which will re-create a dev release).

