### PR TITLE
Resolve #46 and remove circular import dependency plus Buildout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ dist/
 bin/
 build/
 target/
+*.sublime-workspace
+venv/

--- a/src/pds/roundup/__init__.py
+++ b/src/pds/roundup/__init__.py
@@ -2,25 +2,7 @@
 
 '''🤠 PDS Roundup: Continuous Integration and Development'''
 
-from .context import Context
-from .step import Step
 import pkg_resources
-
-
-def contextFactories():
-    # ☑️ TODO: Think about a priority list instead of a dictionary.
-    #
-    # For example, we could have a PythonBuildoutContext which has setup.cfg, setup.py, but also
-    # buildout.cfg and bootstrap.py; if we detect those, we can do a builout-based context instead
-    # of a plain Python context.
-    from ._python import PythonContext
-    from ._maven import MavenContext
-    return {
-        'setup.cfg':   PythonContext,
-        'setup.py':    PythonContext,
-        'pom.xml':     MavenContext,
-        'project.xml': MavenContext
-    }
 
 
 def _read_version():
@@ -38,6 +20,4 @@ __version__ = VERSION = _read_version()
 __all__ = (
     __version__,
     VERSION,
-    Context,
-    Step,
 )

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -2,7 +2,7 @@
 
 '''🤠 PDS Roundup: Maven context'''
 
-from . import Context
+from .context import Context
 from .errors import InvokedProcessError, MissingEnvVarError
 from .step import Step, StepName, NullStep, ChangeLogStep, DocPublicationStep, RequirementsStep
 from .util import invoke, invokeGIT

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -2,7 +2,7 @@
 
 '''PDS Roundup: Python context'''
 
-from . import Context
+from .context import Context
 from .errors import MissingEnvVarError
 from .step import Step, StepName, NullStep, ChangeLogStep, RequirementsStep, DocPublicationStep
 from .util import invoke, invokeGIT, BRANCH_RE, findNextMicro

--- a/src/pds/roundup/assembly.py
+++ b/src/pds/roundup/assembly.py
@@ -84,3 +84,20 @@ class StablePDSAssembly(PDSAssembly):
 class UnstablePDSAssembly(PDSAssembly):
     '''The unstable (in-development) PDS assembly'''
     pass
+
+
+class IntegrativePDSAssembly(UnstablePDSAssembly):
+    '''An assembly for integrations; this is unstable but omits the requirements and
+    changelog generation steps.
+
+    See https://github.com/NASA-PDS/roundup-action/issues/46 for more information.
+    '''
+    pdsSteps = [
+        StepName.unitTest,
+        StepName.integrationTest,
+        StepName.docs,
+        StepName.build,
+        StepName.artifactPublication,
+        StepName.githubRelease,
+        StepName.docPublication,
+    ]

--- a/src/pds/roundup/context.py
+++ b/src/pds/roundup/context.py
@@ -33,7 +33,7 @@ class Context(object):
         '''Create a new context for given current working directory, ``cwd``, and the given
         ``environ``ment variables, and the parsed command-line ``args``.
         '''
-        from . import contextFactories
+        from .util import contextFactories
         factories, factory = contextFactories(), None
         for entry in os.listdir(cwd):
             factory = factories.get(entry)

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -124,3 +124,19 @@ def findNextMicro():
             ex.error.stderr.decode('utf-8')
         )
         return 0
+
+
+def contextFactories():
+    # ☑️ TODO: Think about a priority list instead of a dictionary.
+    #
+    # For example, we could have a PythonBuildoutContext which has setup.cfg, setup.py, but also
+    # buildout.cfg and bootstrap.py; if we detect those, we can do a builout-based context instead
+    # of a plain Python context.
+    from ._python import PythonContext
+    from ._maven import MavenContext
+    return {
+        'setup.cfg':   PythonContext,
+        'setup.py':    PythonContext,
+        'pom.xml':     MavenContext,
+        'project.xml': MavenContext
+    }


### PR DESCRIPTION
## 📜 Summary

Merge this if you dare and it'll resolve #46. BUT WAIT THERE'S MORE! This merge will also remove a circular import dependency that required you to have `github3.py` pre-installed in your Python environment. Now you can develop this package the usual way with `python setup.py develop` or `pip install --editable .`. How much would you pay for this PR? Well don't answer, because merging this will also get rid of the now-hated [Buildout](http://www.buildout.org/en/latest/)! All this for the low, low price of reviewing and merging!

##  🩺Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners, etc.).

##  🧩Related Issues

- #46 

