### PR TITLE
Resolve #49

### DIFF
--- a/src/pds/roundup/main.py
+++ b/src/pds/roundup/main.py
@@ -42,9 +42,9 @@ def _parseArgs():
     )
 
     parser.add_argument(
-        '-D', '--documentation-dir', default='None',
-        help='📦 Directory where the online documentation is generated, '
-             'default value are /docs/build for python and /target/staging for maven'
+        '-D', '--documentation-dir',
+        help='📄 Directory where the online documentation is generated; '
+             'default values are docs/build for Python and target/staging for Maven'
     )
 
     # Maven 😩
@@ -79,7 +79,16 @@ def main():
     '''Main entrypoint'''
     args = _parseArgs()
     logging.basicConfig(level=args.loglevel)
-    context = Context.create(os.getcwd(), populateEnvVars(os.environ), args)
+    cwd = os.getcwd()
+    context = Context.create(cwd, populateEnvVars(os.environ), args)
+    if context is None:
+        contents = ', '.join(os.listdir(cwd))
+        _logger.critical("💥 No usable context in «%s»; note I can only handle Python and Maven projects so far", cwd)
+        if not contents:
+            _logger.critical('🤷‍♀️ The directory is empty; that might have something to do with it 😝')
+        else:
+            _logger.critical("🔎 Here's what's in that directory: %s", contents)
+        sys.exit(1)
 
     # Bonus package time
     if args.packages:


### PR DESCRIPTION
## 📜 Summary

Merge this if you dare to resolve #49. This checks if the doc dir doesn't exist and skips trying to publish it if it does not. Also, it fixes an issue from an earlier approved merge with a literal value of `'None'` is the default for the documentation directory, _not_ the Python constant `None`. Finally, it also adds some better logging when used in a directory that wasn't a usable Roundup context, such as a Ruby project or (in my testing) an empty directory.

## 🩺Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners, etc.).

## 🧩 Related Issues

#49 
