### PR TITLE
Resolve #36 (empty documentation.zip asset)

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -216,4 +216,4 @@ class _ArtifactPublicationStep(_MavenStep):
 
 class _DocPublicationStep(DocPublicationStep):
 
-    default_documentation_dir = 'target/site'
+    default_documentation_dir = 'target/staging'

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -220,11 +220,15 @@ class _DocPublicationStep(DocPublicationStep):
 
     def getDocDir(self):
         # Return the user's preference, if given
-        if self.assembly.context.args.documentation_dir:
-            return self.assembly.context.args.documentation_dir
+        userDocs = self.assembly.context.args.documentation_dir
+        if userDocs:
+            _logger.debug('🙋‍♀️ User has specified a doc dir of «%s», so using it', userDocs)
+            return userDocs
 
         # Otherwise, use the staging directory if it exists, otherwise use the site directory
         if os.path.isdir('target/staging'):
+            _logger.debug('🎭 The staging dir exists for docs, so using it')
             return 'target/staging'
         else:
+            _logger.debug('🏗 Defaulting to site dir for docs')
             return 'target/site'

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -217,3 +217,14 @@ class _ArtifactPublicationStep(_MavenStep):
 class _DocPublicationStep(DocPublicationStep):
 
     default_documentation_dir = 'target/staging'
+
+    def getDocDir(self):
+        # Return the user's preference, if given
+        if self.assembly.context.args.documentation_dir:
+            return self.assembly.context.args.documentation_dir
+
+        # Otherwise, use the staging directory if it exists, otherwise use the site directory
+        if os.path.isdir('target/staging'):
+            return 'target/staging'
+        else:
+            return 'target/site'

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -121,7 +121,7 @@ class _MavenStep(Step):
         '''Invoke Maven, creating a ``settings.xml`` file each time as necessary'''
         self._createSettingsXML()
         self._createKeyring()
-        argv = ['mvn'] + args
+        argv = ['mvn', '--quiet'] + args
         return invoke(argv)
 
 

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -151,8 +151,6 @@ class _DocsStep(_MavenStep):
 
 class _BuildStep(_MavenStep):
 
-
-
     def execute(self):
         _logger.debug('Maven build step')
         self.invokeMaven(self.assembly.context.args.maven_build_phases.split(','))
@@ -218,4 +216,4 @@ class _ArtifactPublicationStep(_MavenStep):
 
 class _DocPublicationStep(DocPublicationStep):
 
-    default_documentation_dir = 'target/staging'
+    default_documentation_dir = 'target/site'

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -206,6 +206,9 @@ class DocPublicationStep(Step):
 
             if not foundFiles:
                 _logger.info('🧐 No doc files in %s, so I am not updating the `documentation.zip` asset', docDir)
+                if docDir == 'target/staging':
+                    _logger.debug('🙁 Here is what is in target')
+                    invoke(['/bin/ls', '-R', 'target'])
                 return
 
             # Remove any existing ``documentation.zip``

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -206,6 +206,7 @@ class DocPublicationStep(Step):
 
             if not foundFiles:
                 _logger.info('🧐 No doc files in %s, so I am not updating the `documentation.zip` asset', docDir)
+                return
 
             # Remove any existing ``documentation.zip``
             for asset in release.assets():

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -206,6 +206,9 @@ class DocPublicationStep(Step):
 
             if not foundFiles:
                 _logger.info('🧐 No doc files in %s, so I am not updating the `documentation.zip` asset', docDir)
+                parent = os.path.abspath(os.path.join(docDir, '..'))
+                _logger.debug('🙁 Here is what is in the doc dir parent %s:', parent)
+                invoke(['/bin/ls', '-lR', parent])
                 return
 
             # Remove any existing ``documentation.zip``

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -206,9 +206,6 @@ class DocPublicationStep(Step):
 
             if not foundFiles:
                 _logger.info('🧐 No doc files in %s, so I am not updating the `documentation.zip` asset', docDir)
-                if docDir == 'target/staging':
-                    _logger.debug('🙁 Here is what is in target')
-                    invoke(['/bin/ls', '-R', 'target'])
                 return
 
             # Remove any existing ``documentation.zip``


### PR DESCRIPTION
## 📜 Summary

Merge this if you PDS-dare and you might just resolve #36 and help ensure PDS-Maven-based PDS repositories get a non-empty `documentation.zip` asset tacked onto their GitHub release.

## 🩺 Test Data and/or Report

Well, let me tell you a lil' something about GitHub Actions. If you really want an isolated test of this, you'd need a massive test harness (which would include a duplicate GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners so people would know the difference between the test and the real things, etc.).

**But** I have been committing directly `main` on the [NASA PDS PDS Template Repo (Java)](https://github.com/NASA-PDS/pds-template-repo-java) and trying it out there and we went from this:

![Screen Shot 2021-08-04 at 12 58 27 PM](https://user-images.githubusercontent.com/814813/128237844-0f76d350-f76c-4628-ac07-0f36e194354d.png)

to this:

![Screen Shot 2021-08-04 at 12 58 38 PM](https://user-images.githubusercontent.com/814813/128237868-337df360-50ec-4f9e-b0fc-caa208e3dfc2.png)

which looks pretty good to me.

## 🧩 Related Issues

- #36 
