### PR TITLE
Resolve #56

### DIFF
--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -79,12 +79,13 @@ class _BuildStep(_PythonStep):
             # a compliant version string and so we can shoehorn Maven-style "SNAPSHOT" releases
             # into the Test PyPi—something for which I'm not sure it was even intended 😒
             candidate = invokeGIT(['describe', '--always', '--tags'])
+            slate = datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
             match = re.match(r'^(v\d+\.\d+\.\d+)', candidate)
             if match is None:
-                _logger.info("🤷‍♀️ No 'v1.2.3' style tags in this repo so skipping unstable build")
-                return
-            slate = datetime.datetime.utcnow().strftime('%Y%m%d%H%M%S')
-            tag = match.group(1) + '-dev-' + slate
+                _logger.info("🐣 No 'v1.2.3' style tags in this repo so assuming we start with 0.0.0; happy birthday!")
+                tag = 'v0.0.0-dev-' + slate
+            else:
+                tag = match.group(1) + '-dev-' + slate
             git_config()
             try:
                 invokeGIT(['tag', '--annotate', '--force', '--message', f'Snapshot {slate}', tag])


### PR DESCRIPTION
## 📜 Summary

Merge this and new Python repositories with no prior version tags  just might get a "snapshot" build made correctly, resolving issue #56.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners, etc.).

## 🧩 Related Issues

- #56 
