### PR TITLE
Update pds-github-util release script calls with new snapshot flag

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -192,11 +192,9 @@ class _GitHubReleaseStep(_MavenStep):
         # create new dev tag if build is successful
         if not self.assembly.isStable():
             self._create_dev_tag()
-            # NASA-PDS/roundup-action#25; although ``maven-release`` and ``maven-snapshot-release`` are
-            # the same script, they must examine argv[0] to change their behavior.
             invoke(['maven-release', '--token', token])
         else:
-            invoke(['maven-snapshot-release', '--token', token])
+            invoke(['maven-release', '--snapshot', '--token', token])
 
 
 class _ArtifactPublicationStep(_MavenStep):

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -161,11 +161,9 @@ class _GitHubReleaseStep(_PythonStep):
         self._pruneDev()
         if self.assembly.isStable():
             self._tagRelease()
-            # NASA-PDS/roundup-action#25; although ``python-release`` and ``python-snapshot-release`` are
-            # the same script, they must examine argv[0] to change their behavior.
             invoke(['python-release', '--token', token])
         else:
-            invoke(['python-snapshot-release', '--token', token])
+            invoke(['python-release', '--snapshot', '--token', token])
 
 
 class _ArtifactPublicationStep(_PythonStep):


### PR DESCRIPTION
Update calls to `maven|python-snapshot-release` to instead use the
`--snapshot` flag added to `maven|python-release`. The `snapshot`
version of these scripts have been removed with the changes in
NASA-PDS/pds-github-util#36

Resolve #57
