### PR TITLE
Fix Python snapshot release removal handling

### DIFF
--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -116,8 +116,8 @@ class _GitHubReleaseStep(_PythonStep):
             _logger.info('🤔 Unshallow prune fetch tags failed, so trying without unshallow')
             invokeGIT(['fetch', '--prune', '--tags'])
 
-        # Next, find all the tags with "dev" in their name and delete them:
-        tags = invokeGIT(['tag', '--list', '*dev*']).split('\n')
+        # Next, find all the tags with SNAPSHOT in their name and delete them
+        tags = invokeGIT(['tag', '--list', '*SNAPSHOT*']).split('\n')
         for tag in tags:
             tag = tag.strip()
             if not tag: continue


### PR DESCRIPTION
Update Python roundup handling so that SNAPSHOT tags are, again, removed
during out build. Changes in `pds-github-util` updated the Python snapshot
release handling to use "SHAPSHOT" like our Java releases. It was missed
that the check for these tags was hard coded to "*dev*" here. We may
want to update this in the future so it's not hard coded. Or that might
be wasted worked and not matter.

This addresses one of the issues raised in #52
