### PR TITLE
Python release build step update to use SNAPSHOT instead of dev

### DIFF
--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -83,9 +83,9 @@ class _BuildStep(_PythonStep):
             match = re.match(r'^(v\d+\.\d+\.\d+)', candidate)
             if match is None:
                 _logger.info("🐣 No 'v1.2.3' style tags in this repo so assuming we start with 0.0.0; happy birthday!")
-                tag = 'v0.0.0-dev-' + slate
+                tag = 'v0.0.0-SNAPSHOT-' + slate
             else:
-                tag = match.group(1) + '-dev-' + slate
+                tag = match.group(1) + '-SNAPSHOT-' + slate
             git_config()
             try:
                 invokeGIT(['tag', '--annotate', '--force', '--message', f'Snapshot {slate}', tag])


### PR DESCRIPTION
Update the Python release BuildStep to label releases with `SNAPSHOT`
instead of `dev` for consistency with changes made in #52 and #57.

Resolve #62