### PR TITLE
Resolve #64

### DIFF
--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -52,9 +52,13 @@ class _UnitTestStep(_PythonStep):
     '''A step to take with Python unit'''
     def execute(self):
         _logger.debug('Python unit test step')
-        # Since we're already in Python we could test directly, but the execution environment might
-        # have set up a special ``python`` executable that has extra features needed for testing.
-        invoke(['python', 'setup.py', 'test'])
+        try:
+            _logger.debug('Trying the new way: installing the dev extra using ``pip`` and then running ``tox``')
+            invoke(['pip', 'install', '--editable', '.[dev]'])
+            invoke(['tox'])
+        except (InvokedProcessError, FileNotFoundError):
+            _logger.debug("OK, the new way didn't work, trying the old way")
+            invoke(['python', 'setup.py', 'test'])
 
 
 class _IntegrationTestStep(_PythonStep):


### PR DESCRIPTION
## 📜 Summary

Merge this to resolve #64 by having the Roundup try `pip install --editable .[dev] && tox` first and then `python setup.py test` second in order to run unit+functional+integration+acceptance+user+… tests.

Note that [there's a pull request that must be merged and a new GitHub Actions Base published to Docker Hub](https://github.com/NASA-PDS/github-actions-base/pull/21) before this can be merged.

## 🩺 Test Data and/or Report

There's no way to test this without a massive test harness (which would include: GitHub Actions ecosystem, actions runners, virtual machines, public key infrastructure, image registries, OSSRH stub, PyPI stub, robots.txt to prevent dev sites crawling, warning banners, etc.).


## 🧩 Related Issues

- #64 
- NASA-PDS/github-actions-base#20
- NASA-PDS/pds-doi-service#247