### PR TITLE
Put away final sandbox toy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ COPY       src/ ./src
 ENTRYPOINT ["/usr/local/bin/roundup"]
 
 RUN : &&\
-    pip install 'git+git://github.com/nasa-pds-engineering-node/pds-github-util@stable#egg=pds_github_util' &&\
+    pip install 'git+git://github.com/NASA-PDS/pds-github-util@stable#egg=pds_github_util' &&\
     python3 setup.py install --optimize=2 &&\
     :


### PR DESCRIPTION
## 📜 Summary

Use `pds-github-util@stable` from `NASA-PDS` instead of the sandbox `nasa-pds-engineering-node`.

## 🩺 Test Data and/or Report

None available.

##  🧩 Related Issues

- https://github.com/NASA-PDS/pds-github-util/pull/53