### PR TITLE
Resolve #81

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -290,7 +290,8 @@ class _CleanupStep(_MavenStep):
         match = re.match(r'(\d+)\.(\d+)\.(\d+)', pomVersion)
         if not match:
             raise RoundupError(f'Expected Major.Minor.Micro version in pom but got «{pomVersion}»')
-        major, minor, micro = int(match.group(1)), int(match.group(2)), int(match.group(3)) + 1
+        # NASA-PDS/roundup-action#81: Jordan would prefer the `minor` version get bumped, not the `micro` version:
+        major, minor, micro = int(match.group(1)), int(match.group(2)) + 1, int(match.group(3))
         newVersion = f'{major}.{minor}.{micro}-SNAPSHOT'
         _logger.debug('🔖 Setting version %s in the pom', newVersion)
         self.invokeMaven(['-DgenerateBackupPoms=false', f'-DnewVersion={newVersion}', 'versions:set'])

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -292,7 +292,7 @@ class _CleanupStep(_MavenStep):
             raise RoundupError(f'Expected Major.Minor.Micro version in pom but got «{pomVersion}»')
         # NASA-PDS/roundup-action#81: Jordan would prefer the `minor` version get bumped, not the `micro` version:
         major, minor, micro = int(match.group(1)), int(match.group(2)) + 1, int(match.group(3))
-        newVersion = f'{major}.{minor}.{micro}-SNAPSHOT'
+        newVersion = f'{major}.{minor}.0-SNAPSHOT'
         _logger.debug('🔖 Setting version %s in the pom', newVersion)
         self.invokeMaven(['-DgenerateBackupPoms=false', f'-DnewVersion={newVersion}', 'versions:set'])
         commit('pom.xml', f'Setting snapshot version for {major}.{minor}.{micro}-SNAPSHOT')

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -284,7 +284,7 @@ class _CleanupStep(_PythonStep):
             return
         # NASA-PDS/roundup-action#81: Jordan would prefer the `minor` version get bumped, not the `micro` version:
         major, minor, micro = int(match.group(1)), int(match.group(2)) + 1, int(match.group(3))
-        new_version = f'{major}.{minor}.{micro}'
+        new_version = f'{major}.{minor}.0'
         _logger.debug('🔖 Setting version %s in src/…/VERSION.txt', new_version)
         with open(version_file, 'w') as f:
             f.write(f'{new_version}\n')

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -282,7 +282,8 @@ class _CleanupStep(_PythonStep):
         if not match:
             _logger.info(f'Expected Major.Minor.Micro version in src/…/VERSION.txt but got «{version}» but whatever')
             return
-        major, minor, micro = int(match.group(1)), int(match.group(2)), int(match.group(3)) + 1
+        # NASA-PDS/roundup-action#81: Jordan would prefer the `minor` version get bumped, not the `micro` version:
+        major, minor, micro = int(match.group(1)), int(match.group(2)) + 1, int(match.group(3))
         new_version = f'{major}.{minor}.{micro}'
         _logger.debug('🔖 Setting version %s in src/…/VERSION.txt', new_version)
         with open(version_file, 'w') as f:


### PR DESCRIPTION
## 🗒️ Summary

Merge this if you dare and you'll have the `minor` version instead of the `micro` version bumped at the end of a stable release for version `major.minor.micro`.

## ⚙️ Test Data and/or Report

See the results of testing in the sandbox:

- Maven: https://github.com/nasa-pds-engineering-node/exemplar/actions
- Python: https://github.com/nasa-pds-engineering-node/epitome/actions

## ♻️ Related Issues

- #81 
