### PR TITLE
Resolve #87

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -72,7 +72,12 @@ class _MavenStep(Step):
             for fn in filenames:
                 if fn == 'pom.xml':
                     path = os.path.join(folder, fn)
-                    invokeGIT(['add', path])
+                    try:
+                        invokeGIT(['add', path])
+                    except InvokedProcessError:
+                        # #87: we may have just tried to add a generated pom.xml which is in the ``.gitignore``
+                        # file. No need to add it! Just treat this softly and continue on.
+                        _logger.info('🤫 Ignoring ``git add`` on %s', path)
         invokeGIT(['commit', '--allow-empty', '--message', message])
         # TODO: understand why a simple push does not work and make it work
         # see bug https://github.com/actions/checkout/issues/317


### PR DESCRIPTION
## 🗒️ Summary

Merge this to treat `git add` on `pom.xml` files that are explicitly listed in `.gitignore` as a soft error. This allows us to do `versions:set` without having to commit generated `pom.xml` files.

## ⚙️ Test Data and/or Report

N/A as we don't have a harness or fixture for GitHub Actions.

## ♻️ Related Issues

- #87 