### PR TITLE
Remove --force from commit

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -81,7 +81,7 @@ class _MavenStep(Step):
         invokeGIT(['commit', '--allow-empty', '--message', message])
         # TODO: understand why a simple push does not work and make it work
         # see bug https://github.com/actions/checkout/issues/317
-        invokeGIT(['push', 'origin',  'HEAD:main', '--force'])
+        invokeGIT(['push', 'origin',  'HEAD:main'])
 
 
 class _PreparationStep(Step):

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -79,8 +79,13 @@ class _MavenStep(Step):
                         # file. No need to add it! Just treat this softly and continue on.
                         _logger.info('🤫 Ignoring ``git add`` on %s', path)
         invokeGIT(['commit', '--allow-empty', '--message', message])
-        # TODO: understand why a simple push does not work and make it work
-        # see bug https://github.com/actions/checkout/issues/317
+
+        # To resolve #76, @jordnpadams removed the ``--force`` from the git invocation below ↓
+        #
+        # Which is nice, because it's good to protect the `main` branch from recently made commits
+        # & merged. However, we added the ``--force`` in the first place because we randomly got
+        # ``You are not currently on a branch`` errors.  Somehow, this is related to
+        # https://github.com/actions/checkout/issues/317
         invokeGIT(['push', 'origin',  'HEAD:main'])
 
 


### PR DESCRIPTION
This may have been put there for a reason, but it causes funky merge conflicts in branches from main, plus, if someone sneaks in a commit on main before the merge, I would like this release tagging to fail and someone to look at it

Resolves #76 
