### PR TITLE
Resolve #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This causes the Roundup to use OpenJDK 11 and also installs the `pdfgrep` packag
 
 #### ☕️ Java Note
 
-If you install an JDK older than OpenJDK 1.8.0_252, you may need to also set the `JAVA_HOME` environment variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
+If you install a JDK older than OpenJDK 1.8.0_252, you may need to also set the `JAVA_HOME` environment variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
 
 
 ### 👮‍♂️ GitHub Admin Token
@@ -112,6 +112,9 @@ There are several different flavors of roundups that you can specify `with` the 
 -   `unstable` — this is the same as the `stable` PDS assembly but for unstable software releases. It does all the same steps as the stable assembly, but OSSRH artifacts are marked as `SNAPSHOT`s, the `test.pypi.org` is used instead of `pypi.org`, etc. This is the default if you don't specify an assembly.
 -   `integration` — this is the same as the `unstable` PDS assembly, but omits the requirements generation and changelog generation steps.
 -   `noop` — this is an assembly that does nothing, i.e., "no operation".
+-   `env` — this is an assembly whose steps are defined by environment variables:
+    -   `ROUNDUP_STABLE` set to `1` or `true` for a stable assembly, unstable otherwise
+    -   `ROUNDUP_STEPS` set to a comam-separated list of step names to execute, such as `test,docs`
 
 
 ### 🛫 Releases

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -3,7 +3,7 @@
 '''🤠 PDS Roundup: A step takes you further towards a complete roundup'''
 
 from enum import Enum
-from .util import git_pull, commit, invoke, invokeGIT, findNextMicro, BRANCH_RE
+from .util import git_pull, commit, invoke, invokeGIT, findNextMicro, TAG_RE
 import logging, github3, tempfile, zipfile, os
 
 _logger = logging.getLogger(__name__)
@@ -86,13 +86,14 @@ class ChangeLogStep(Step):
         For NASA-PDS/roundup-action#29.
         '''
         _logger.debug('🏷 For changelog generation, figuring out the future release')
-        branch = invokeGIT(['branch', '--show-current']).strip()
-        if not branch:
-            _logger.debug('🕊 Cannot determine what branch we are on, so using «unknown»')
+
+        tag = invokeGIT(['describe', '--tags', '--abbrev=0', '--match', 'release/*']).strip()
+        if not tag:
+            _logger.debug('🕊 Cannot determine what tag we are on for changelog future, so using «unknown»')
             return '«unknown»'
-        match = BRANCH_RE.match(branch)
+        match = TAG_RE.match(tag)
         if not match:
-            _logger.debug('🐎 This is not a ``release/`` branch, so using «unknown»')
+            _logger.debug('🐎 This is not a ``release/`` tag, so using «unknown»')
             return '«unknown»'
         major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
         _logger.debug('🔖 Okay, we got version %d.%d.%s', major, minor, micro)

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -11,7 +11,7 @@ _logger = logging.getLogger(__name__)
 # Constants
 # =========
 
-BRANCH_RE = re.compile(r'^release/(\d+)\.(\d+)(\.(\d+))?')
+TAG_RE = re.compile(r'^release/(\d+)\.(\d+)(\.(\d+))?')
 VERSION_RE = re.compile(r'^v(\d+)\.(\d+)\.(\d+)')
 
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this if you dare mighty things and wish to resolve #90. Note that you'll also need to change every repository's `stable.yaml` file as follows:
```yaml
on:
    push:
        branches:
            - 'release/*'
```
to
```yaml
on:
    push:
        tags:
            - 'release/*'
```
since the Roundup Action will look for a tag with a release name now, not a branch anymore.

## ⚙️ Test Data and/or Report

See https://github.com/nasa-pds-engineering-node/exemplar and https://github.com/nasa-pds-engineering-node/epitome for successful Roundups.

## ♻️ Related Issues

- #90 
