### PR TITLE
Resolve #104

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ There are several different flavors of roundups that you can specify `with` the 
 
 The Roundup includes built-in support to make official releases of software, publishing artifacts to well-known repositories, and including release archives on GitHub. The [PDS Java Template Repository](https://github.com/NASA-PDS/pds-template-repo-java) (historically called the "generic template") and the [PDS Python Template Repository](https://github.com/NASA-PDS/pds-template-repo-python) (historically called the Python template) have the correct GitHub Actions workflows to support this. If you create a new PDS repository from those templates, you're all set to roundup! Yee-haw!
 
-To make an offical release of software version `VERSION`, create a branch called `release/VERSION` and push it to GitHub. For example, to release version 2.0.17 of your software based on the latest `main`:
+To make an offical release of software version `VERSION`, create a tag called `release/VERSION` and push it to GitHub. For example, to release version 2.0.17 of your software based on the latest `main`:
 ```console
 $ git checkout main
 $ git pull
-$ git branch --track release/2.0.17
+$ git tag --annotate --message "Release of 2.0.17" release/2.0.17
 $ git push origin release/2.0.17
 ```
 


### PR DESCRIPTION
## 🗒️ Summary

Resolve #104 by doing the following:

-   Prune tags based on the kind of assembly (stable vs unstable) and package (Maven vs Python)
    -   Which comes down to `release/*` for unstable releases
        -   This get pruned later in the pipeline for stable releasese
    -   And `*SNAPSHOT*` or `*dev*` for stable releases
-   Also prune tags prior to changelog generation
-   Fix some old documentation in the README

👉 **Note**: Once these changes are committed and a new `stable` Roundup Action is indicated, the next changelog generated after a roundup will still have `release/*` tags appearing it. However, these will get cleaned up on the _second_ roundup after that.


## ⚙️ Test Data and/or Report

See the sandbox.


## ♻️ Related Issues

- #104 
