### PR TITLE
Adjust some version pins and roundup roundup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     github3.py
     pds-github-util
     requests==2.23.0
-    packaging==20.9
+    packaging==21.0
     sphinx
     twine
     wheel

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -13,6 +13,9 @@ import logging, os, re, shutil
 
 _logger = logging.getLogger(__name__)
 
+# This should match what's in github-actions-base (goodness, this is complex!)
+SPHINX_VERSION = '3.2.1'
+
 
 class PythonContext(Context):
     '''A Python context supports Python software proejcts'''
@@ -69,7 +72,7 @@ class _PreparationStep(_PythonStep):
         # Make sure we have the latest of pip+setuptools+wheel
         invoke(['pip', 'install', '--quiet', '--upgrade', 'pip', 'setuptools', 'wheel'])
         # #79: ensure that the venv has its own ``sphinx-build``
-        invoke(['pip', 'install', '--quiet', '--ignore-installed', 'sphinx'])
+        invoke(['pip', 'install', '--quiet', '--ignore-installed', f'sphinx=={SPHINX_VERSION}'])
         # Now install the package being rounded up
         invoke(['pip', 'install', '--editable', '.[dev]'])
         # ☑️ TODO: what other prep steps are there? What about VERSION.txt overwriting?
@@ -99,7 +102,7 @@ class _IntegrationTestStep(_PythonStep):
 class _DocsStep(_PythonStep):
     '''A step that uses Sphinx to generate documentation'''
     def execute(self):
-        invoke(['sphinx-build', '-a', '-b', 'html', 'docs/source', 'docs/build'])
+        invoke(['/usr/local/bin/sphinx-build', '-a', '-b', 'html', 'docs/source', 'docs/build'])
 
 
 class _VersionBumpingStep(_PythonStep):
@@ -200,9 +203,9 @@ class _GitHubReleaseStep(_PythonStep):
         self._pruneDev()
         if self.assembly.isStable():
             self._tagRelease()
-            invoke(['python-release', '--debug', '--token', token])
+            invoke(['/usr/local/bin/python-release', '--debug', '--token', token])
         else:  # It's unstable release
-            invoke(['python-release', '--debug', '--snapshot', '--token', token])
+            invoke(['/usr/local/bin/python-release', '--debug', '--snapshot', '--token', token])
             self._pruneReleaseTags()
 
 
@@ -212,7 +215,7 @@ class _ArtifactPublicationStep(_PythonStep):
         # 😮 TODO: It'd be more secure to use PyPI access tokens instead of usernames and passwords!
 
         argv = [
-            'twine',
+            '/usr/local/bin/twine',
             'upload',
             '--username',
             self.getCheeseshopCredentials()[0],


### PR DESCRIPTION
## 🗒️ Summary

-   Adjust some version pins both in setup metadata and in the processing of Python packages (Sphinx 3.2.1)
-   Explicitly use the Roundup's own (i.e., the container's) Python and not the virtual environment's Python
    -   The virtual environment's Python is for the package being "rounded up"
    -   The container's Python is for Roundup Action itself
-   👉 **Note:** These changes won't work unless `pds-github-util` has a new `@stable` tag [merged from this PR](https://github.com/NASA-PDS/pds-github-util/pull/71) as well

## ⚙️ Test Data and/or Report

See: https://github.com/nasa-pds-engineering-node/sumo-tools/actions/runs/4056685843

## ♻️ Related Issues

- #105 
