### PR TITLE
Mark the GitHub workspace directory as safe for git

### DIFF
--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -92,7 +92,12 @@ def invokeGIT(gitArgs):
 
 
 def git_config():
-    '''Prepare necessary git configuration or else thing might fail'''
+    '''Prepare necessary git configuration or else things might fail'''
+
+    # Starting with git 2.36, we need to tell git our directory is safe to use
+    invokeGIT(['config', '--global', '--add', 'safe.directory', '/github/workspace'])
+
+    # And give the bot its credit
     invokeGIT(['config', '--local', 'user.email', 'pdsen-ci@jpl.nasa.gov'])
     invokeGIT(['config', '--local', 'user.name', 'PDSEN CI Bot'])
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this to make the Roundup Action work with git 2.36, which introduced a security enhancement that helps protect parent `.git` directories from influencing the current repository.

## ⚙️ Test Data and/or Report

See https://github.com/nasa-pds-engineering-node/registry-common/actions/runs/4641371985

## ♻️ Related Issues

- #110 
