### PR TITLE
Ensure we call git_config in the `PreparationStep` for both Maven and Python

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -158,6 +158,7 @@ class _PreparationStep(Step):
 
     def execute(self):
         _logger.debug('Maven preparation step')
+        git_config()
         self._createSettingsXML()
         self._createKeyring()
 

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -7,7 +7,7 @@ from .errors import InvokedProcessError, RoundupError
 from .errors import MissingEnvVarError
 from .step import ChangeLogStep as BaseChangeLogStep
 from .step import Step, StepName, NullStep, RequirementsStep, DocPublicationStep
-from .util import invoke, invokeGIT, TAG_RE, commit, delete_tags
+from .util import invoke, invokeGIT, TAG_RE, commit, delete_tags, git_config
 from pds_github_util.release._python_version import TextFileDetective
 import logging, os, re, shutil
 
@@ -63,6 +63,7 @@ class _PreparationStep(_PythonStep):
     '''Prepare the python repository for action.'''
     def execute(self):
         _logger.debug('Python preparation step')
+        git_config()
         shutil.rmtree('venv', ignore_errors=True)
         # We add access to system site packages so that projects can save time if they need numpy, pandas, etc.
         invoke(['python', '-m', 'venv', '--system-site-packages', 'venv'])


### PR DESCRIPTION
## 🗒️ Summary

@tloubrieu-jpl reported that [this workflow](https://github.com/NASA-PDS/registry-api/actions/runs/4670289013/jobs/8269830978) failed with the same error caused by `git` 2.36. Merge this ensure `git_config` gets called.

## ⚙️ Test Data and/or Report

Left as an exercise to the reader.

## ♻️ Related Issues

See https://jpl.slack.com/archives/DTZT0UJ1W/p1681234945030849