### PR TITLE
Resolve #116

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ COPY       src/ ./src
 ENTRYPOINT ["/usr/local/bin/roundup"]
 
 RUN : &&\
-    pip install 'git+https://github.com/NASA-PDS/pds-github-util@stable#egg=pds_github_util' &&\
+    pip install 'lasso.releasers~=1.0.0' 'lasso.requirements~=1.0.0' &&\
     python3 setup.py install --optimize=2 &&\
     :


### PR DESCRIPTION
## 🗒️ Summary

This switches the Roundup Action from the monopolistic pds-github-util to the liberated separate packages lasso.releasers and lasso.requirements. Merge this to resolve #116.

## ⚙️ Test Data and/or Report

Tested in the "sandbox" organization against these two repositories:

- [Python example](https://github.com/nasa-pds-engineering-node/epitome/actions/runs/5729552992)
- [Java example](https://github.com/nasa-pds-engineering-node/exemplar/actions/runs/5729556418)

## ♻️ Related Issues

- #116 
