### PR TITLE
Fix issues with transitive dependency conflicts and excise the final vestiges of pds-github-util

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ ENTRYPOINT ["/usr/local/bin/roundup"]
 
 RUN : &&\
     pip install 'lasso.releasers~=1.0.0' 'lasso.requirements~=1.0.0' &&\
-    python3 setup.py install --optimize=2 &&\
+    pip install install /usr/src/roundup &&\
     :

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,19 +24,19 @@ packages = find_namespace:
 package_dir =
     =src
 
-# Note: the ``install_requires`` dependencies below are for development only;
-# for operations, the base Docker image has all of these pre-installed to
-# save time.
+# Note: the ``install_requires`` dependencies below must match certain
+# packages "baked into" the nasapds/github-actions-base which is used
+# by GitHub Actions to save time on spinning up the Roundup's container.
 
 install_requires =
-    github3.py
-    pds-github-util
+    github3.py==1.3.0
     requests==2.23.0
     packaging==21.0
-    sphinx
-    twine
-    wheel
-    lxml
+    sphinx==3.2.1
+    twine==3.4.2
+    wheel==0.40.0
+    lxml==4.6.3
+    sphinx-substitution-extensions==2020.9.30.0
 
 
 [options.package_data]

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -8,7 +8,7 @@ from .errors import MissingEnvVarError
 from .step import ChangeLogStep as BaseChangeLogStep
 from .step import Step, StepName, NullStep, RequirementsStep, DocPublicationStep
 from .util import invoke, invokeGIT, TAG_RE, commit, delete_tags, git_config
-from pds_github_util.release._python_version import TextFileDetective
+from lasso.releasers._python_version import TextFileDetective
 import logging, os, re, shutil
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
## 🗒️ Summary

While developing solutions for [software-issues №55](https://github.com/NASA-PDS/software-issues-repo/issues/55) and [roundup-action №124](https://github.com/NASA-PDS/roundup-action/issues/124), I struggled to comprehend why the Roundup Action seemingly has been functioning fine in the [NASA-PDS](https://github.com/NASA-PDS) organization but not in the [sandbox](https://github.com/nasa-pds-engineering-node)—even after sync'ing to the sandbox.

The issue: the production organization's `stable` tag was still pointing to an older release which never transitioned away from `pds-github-util` and towards the `lasso-*` monopoly-breakup packages. Further, some transitive and unpinned dependencies seemingly have evolved in the intervening time—and this broke the Roundup Action on `main` and in the sandbox.

Merge this to bring things back into check, namely by addressing:

- Container setup was giving different results from `python setup.py install` and `pip install .`; but the former is obsolete anyway so switch to the latter
- The comment about `setup.cfg` requirements was incorrect; those were in fact being used during container setup
- Pin the requirements in `setup.cfg` to conform to those in `github-actions-base` as well as `lasso-releasers` and `lasso-requirements`
- Use the correct "internal anatomy" of `lasso-releasers`, not `pds-github-util`

👉 **Note:** Once this is merged, the pivotal step of moving the `stable` tag must be done so that these changes will actually take effect for all non-sandbox repositories.

## ⚙️ Test Data and/or Report

See successful roundups of these two repositories:

- The [sandbox Maven repository](https://github.com/nasa-pds-engineering-node/exemplar/actions/runs/6655647846)
- The [sandbox Python repository](https://github.com/nasa-pds-engineering-node/epitome/actions/runs/6655710664)

## ♻️ Related Issues

No issue was formally filed for this particular problem; it came about while addressing [software-issues №55](https://github.com/NASA-PDS/software-issues-repo/issues/55) and [roundup-action №124](https://github.com/NASA-PDS/roundup-action/issues/124).