### PR TITLE
Splits version bumping step into two separate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,17 @@ There are several different flavors of roundups that you can specify `with` the 
 
 The Roundup includes built-in support to make official releases of software, publishing artifacts to well-known repositories, and including release archives on GitHub. The [PDS Java Template Repository](https://github.com/NASA-PDS/pds-template-repo-java) (historically called the "generic template") and the [PDS Python Template Repository](https://github.com/NASA-PDS/pds-template-repo-python) (historically called the Python template) have the correct GitHub Actions workflows to support this. If you create a new PDS repository from those templates, you're all set to roundup! Yee-haw!
 
-To make an offical release of software version `VERSION`, create a tag called `release/VERSION` and push it to GitHub. For example, to release version 2.0.17 of your software based on the latest `main`:
+To make an offical release of software version `VERSION`, create a tag called `release/VERSION` and push it to GitHub. For example, to release version 2.1.0 of your software based on the latest `main`:
 ```console
 $ git checkout main
 $ git pull
-$ git tag --annotate --message "Release of 2.0.17" release/2.0.17
-$ git push origin release/2.0.17
+$ git tag --annotate --message "Release of 2.1.0" release/2.1.0
+$ git push origin release/2.1.0
+```
+If a release fails, you can retry it under some circumstances (depending on where it failed) with an invocation like:
+```console
+$ git push --delete release/2.1.0
+$ git push origin release/2.1.0
 ```
 
 

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -36,6 +36,7 @@ class MavenContext(Context):
             StepName.requirements:        RequirementsStep,
             StepName.unitTest:            _UnitTestStep,
             StepName.versionBump:         _VersionBumpingStep,
+            StepName.versionCommit:       _VersionCommittingStep,
         }
         super(MavenContext, self).__init__(cwd, environ, args)
 
@@ -307,7 +308,20 @@ class _VersionBumpingStep(_MavenStep):
         with open('pom.xml', 'r') as f:
             for 𝐋 in f:
                 if 'version' in 𝐋: _logger.debug(f'“{𝐋.strip()}”')
-        self.commit_poms(f'Bumping version for {major}.{minor}.{micro} release')
+
+
+class _VersionCommittingStep(_MavenStep):
+    '''Step that commits the new version, as needed.'''
+    def execute(self):
+        '''Commit the new version number.'''
+        if not self.assembly.isStable():
+            _logger.debug('Skipping version commit for unstable build')
+            return
+        _logger.debug('❗️ Inside the _VersionCommittingStep, here is what the pom.xml looks like as far as <version>')
+        with open('pom.xml', 'r') as f:
+            for 𝐋 in f:
+                if 'version' in 𝐋: _logger.debug(f'“{𝐋.strip()}”')
+        self.commit_poms('Committing poms for stable release')
 
 
 class _CleanupStep(_MavenStep):

--- a/src/pds/roundup/assembly.py
+++ b/src/pds/roundup/assembly.py
@@ -74,6 +74,8 @@ class PDSAssembly(Assembly):
         StepName.changeLog,
         StepName.githubRelease,
         StepName.docPublication,
+        # NASA-PDS/roundup-action#124: split version bumping from version committing
+        StepName.versionCommit,
         StepName.cleanup,
     ]
 

--- a/src/pds/roundup/step.py
+++ b/src/pds/roundup/step.py
@@ -50,6 +50,7 @@ class StepName(Enum):
     requirements        = 'requirements'
     unitTest            = 'unitTest'
     versionBump         = 'versionBump'
+    versionCommit       = 'versionCommit'
 
 
 # Common Steps

--- a/support/run-roundup.sh
+++ b/support/run-roundup.sh
@@ -48,7 +48,7 @@
 
 
 # Constantly
-defaultSteps="preparation,unitTest,integrationTest,changeLog,requirements,docs,versionBump,build,githubRelease,artifactPublication,docPublication,cleanup"
+defaultSteps="preparation,unitTest,integrationTest,changeLog,requirements,docs,versionBump,build,githubRelease,artifactPublication,docPublication,versionCommit,cleanup"
 
 # Check args
 if [ "$#" -lt 2 -o "$#" -gt 3 ]; then


### PR DESCRIPTION
## 🗒️ Summary

Merge this and you'll alter the way a roundup does an assembly. Previously, it had a "version bumping" step that would increase the version number in the system and commit it, then do the rest of the assembly.

However, as #124 noted, if a later step failed, that version number was already committed.

Merge this and "version bumping" gets split into two separate steps:

- An earlier step that increases the version number in the system, whether that's a Python `VERSION.txt` file or the `<version>` key in a Maven POM
- A later step that then commits the changed version file.

## ⚙️ Test Data and/or Report

You can see this work especially in Maven projects which are prone to Sonatype OSSRH central artifactory failures. Note, for example, the runs in the [Maven sandbox repository](https://github.com/nasa-pds-engineering-node/exemplar/actions) (newer actions appear closer to the top, ignore the commit messages—look at the "branch" column):

-   Before the fix
    -   Roundup got triggered by tag `release/5.4.0`
    -   It then triggered a commit to `main`, which would've been fine if `release/5.4.0`'s Roundup hadn't failed in the OSSRH step—**this is the step we want to avoid**
-   After the fix
    -    Roundup got triggered by the tag `release/5.5.0`; it failed
    -    However, above it, there's no commit to `main`
        -    And I retried the `release/5.5.0` two more times—both of which failed—and neither of which had a commit to `main`

Thankfully OSSRH is so flaky this was easy to test. For completion, I also tested it in the [sandbox Python repository](https://github.com/nasa-pds-engineering-node/exemplar/actions). There, you can see `release/3.2.0` which was successful then triggered a commit of the `VERSION.txt` to `main`.

## ♻️ Related Issues

- #124 
