### PR TITLE
Add version label to open bugs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -166,9 +170,9 @@
         "filename": "src/pds/roundup/util.py",
         "hashed_secret": "2cdaeb7565d9036f422d87494886f0295a6e6cd3",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 111
       }
     ]
   },
-  "generated_at": "2023-11-22T18:45:56Z"
+  "generated_at": "2023-12-07T15:42:21Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,6 @@ ENTRYPOINT ["/usr/local/bin/roundup"]
 
 RUN : &&\
     pip install 'lasso.releasers~=1.0.0' 'lasso.requirements~=1.0.0' &&\
+    pip install 'git+https://github.com/NASA-PDS/lasso-issues.git@main' &&\
     pip install install /usr/src/roundup &&\
     :

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -6,7 +6,7 @@ from .context import Context
 from .errors import InvokedProcessError, MissingEnvVarError, RoundupError
 from .step import ChangeLogStep as BaseChangeLogStep
 from .step import Step, StepName, NullStep, DocPublicationStep, RequirementsStep
-from .util import invoke, invokeGIT, TAG_RE, git_config, delete_tags
+from .util import invoke, invokeGIT, TAG_RE, git_config, delete_tags, add_version_label_to_open_bugs
 from lxml import etree
 import logging, os, base64, subprocess, re
 
@@ -300,7 +300,9 @@ class _VersionBumpingStep(_MavenStep):
         if not match:
             raise RoundupError(f'🐎 Stable workflow on tag «{tag}» but not a ``release/`` name!')
         major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
-        _logger.debug('🔖 So we got version %d.%d.%s', major, minor, micro)
+        full_version = f'{major}.{minor}.{micro}'
+        _logger.debug('🔖 So we got version %s', full_version)
+        add_version_label_to_open_bugs(full_version)
         if micro is None:
             raise RoundupError('Invalid release version supplied in tag name. You must supply Major.Minor.Micro')
         self.invokeMaven(['-DgenerateBackupPoms=false', f'-DnewVersion={major}.{minor}.{micro}', 'versions:set'])

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -7,7 +7,7 @@ from .errors import InvokedProcessError, RoundupError
 from .errors import MissingEnvVarError
 from .step import ChangeLogStep as BaseChangeLogStep
 from .step import Step, StepName, NullStep, RequirementsStep, DocPublicationStep
-from .util import invoke, invokeGIT, TAG_RE, commit, delete_tags, git_config
+from .util import invoke, invokeGIT, TAG_RE, commit, delete_tags, git_config, add_version_label_to_open_bugs
 from lasso.releasers._python_version import TextFileDetective
 import logging, os, re, shutil
 
@@ -127,10 +127,13 @@ class _VersionBumpingStep(_PythonStep):
             raise RoundupError(f'🐎 Stable tag of «{tag}» but not a ``release/`` tag')
 
         major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
-        _logger.debug('🔖 So we got version %d.%d.%s', major, minor, micro)
+        full_version = f'{major}.{minor}.{micro}'
+        _logger.debug('🔖 So we got version %s', full_version)
+
         if micro is None:
             raise RoundupError('Invalid release version supplied in tag name. You must supply Major.Minor.Micro')
 
+        add_version_label_to_open_bugs(full_version)
         _logger.debug("Locating VERSION.txt to update with new release version.")
         try:
             version_file = TextFileDetective.locate_file(self.assembly.context.cwd)

--- a/src/pds/roundup/assembly.py
+++ b/src/pds/roundup/assembly.py
@@ -59,7 +59,7 @@ class NoOpAssembly(Assembly):
 
 
 class PDSAssembly(Assembly):
-    '''The PDS-flavored assembly which has 9 different steps'''
+    '''The PDS-flavored assembly which has 13 different steps'''
     pdsSteps = [
         StepName.preparation,
         StepName.unitTest,

--- a/src/pds/roundup/main.py
+++ b/src/pds/roundup/main.py
@@ -112,8 +112,8 @@ def main():
 
     # Sanity check in GitHub Acions logs: show the version of ``pds-github-util`` by calling
     # ``--version`` on any one of its programs.
-    pdsGitHubUtilVersion = invoke(['maven-release', '--version']).strip()
-    _logger.info('🗺 The version of ``pds-github-util`` I shall be using: %s', pdsGitHubUtilVersion)
+    version = invoke(['pds-issues', '--version']).strip()
+    _logger.info('🗺 The version of ``lasso-issues`` I shall be using: %s', version)
 
     # Here we go daddy
     _assemblies[args.assembly](context).roundup()

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -3,7 +3,8 @@
 '''🤠 PDS Roundup — Utilities'''
 
 from .errors import InvokedProcessError
-import subprocess, logging, re
+import subprocess, logging, re, os
+
 
 _logger = logging.getLogger(__name__)
 
@@ -40,6 +41,15 @@ def populateEnvVars(env):
             _logger.warn('⚠️ «%s» not found in environment; some steps may fail', var)
 
     return copy
+
+
+def add_version_label_to_open_bugs(version):
+    _logger.debug('Adding version label to open bugs')
+    owner, repo = os.getenv('GITHUB_REPOSITORY').split('/')
+    invoke([
+        'add-version-label-to-open-bugs', '--labelled-version', version,
+        '--token', os.getenv('ADMIN_GITHUB_TOKEN'), '--github-org', owner, '--github-repo', repo,
+    ])
 
 
 def invoke(argv):


### PR DESCRIPTION
## 🗒️ Summary

Roundup Action now leverages add-version-label-to-open-bugs from Lasso Releasers.

## ⚙️ Test Data and/or Report

See https://github.com/nasa-pds-engineering-node/epitome/ and https://github.com/nasa-pds-engineering-node/exemplar/

## ♻️ Related Issues

- #128 
