### PR TITLE
Support PDS-style Node.js repositories for continuous integration and stable+unstable releases

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,10 +85,6 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
-    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -123,8 +119,8 @@
       "path": "detect_secrets.filters.regex.should_exclude_file",
       "pattern": [
         "\\.secrets..*",
-        "\\.pre-commit-config\\.yaml",
         "\\.git.*",
+        "\\.pre-commit-config\\.yaml",
         "\\.mypy_cache",
         "\\.pytest_cache",
         "\\.tox",
@@ -143,7 +139,7 @@
         "filename": "README.md",
         "hashed_secret": "0ebdbaa404ab765b45b3af96c0e1874401ac3ef3",
         "is_verified": false,
-        "line_number": 94
+        "line_number": 95
       }
     ],
     "action.yaml": [
@@ -153,6 +149,15 @@
         "hashed_secret": "1b21650fca3caf5c234a77fcc47fb5f08cfcbd8a",
         "is_verified": false,
         "line_number": 11
+      }
+    ],
+    "src/pds/roundup/_nodejs.py": [
+      {
+        "type": "Email Address",
+        "filename": "src/pds/roundup/_nodejs.py",
+        "hashed_secret": "2cdaeb7565d9036f422d87494886f0295a6e6cd3",
+        "is_verified": false,
+        "line_number": 78
       }
     ],
     "src/pds/roundup/step.py": [
@@ -174,5 +179,5 @@
       }
     ]
   },
-  "generated_at": "2023-12-07T15:42:21Z"
+  "generated_at": "2024-03-15T19:54:15Z"
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🤠 PDS Engineering Actions: Roundup
 
-This is an [action for GitHub](https://github.com/features/actions) that does a "roundup"; that is, continuous integration and continuous delivery of [PDS](https://pds.nasa.gov/) software. (Somehow we got started on this "Western" kind of terminology and dadgum, we're stickin' with it 🤠.)
+This is an [action for GitHub](https://github.com/features/actions) that does a "roundup"; that is, continuous integration of [PDS](https://pds.nasa.gov/) software. (Somehow we got started on this "Western" kind of terminology and dadgum, we're stickin' with it 🤠.)
 
 
 ## ℹ️ Using this Action
@@ -28,12 +28,13 @@ Depending on the roundup, you may also need the following environment variables:
 -   `pypi_password` — Password for `pypi_username`
 -   `ossrh_username` — Username to use for uploading a snapshot [OSSRH](https://central.sonatype.org/pages/ossrh-guide.html) artifact
 -   `ossrh_password` — Password for `ossrh_username`
+-   `NPMJS_COM_TOKEN` — Token for https://www.npmjs.com/ which must be a granular access token with read/write permission to the `@nasapds` scope
 -   `CODE_SIGNING_KEY` — GPG **private** key (base64 encoded) with which to sign artifacts
 
 
 ### 🍃 Environment
 
-The Roundup Action uses the [NASA-PDS](https://github.com/NASA-PDS) [Github Actions Base](https://github.com/NASA-PDS/github-actions-base) as its starting environment. As of the time of this writing, this is [Alpine Linux 3.12](https://www.alpinelinux.org), [Python 3.8.5](https://www.python.org/), and [Apache Maven 3.6.3](https://maven.apache.org/), which in turns gives you [OpenJDK 1.8.0_252](https://openjdk.java.net/) (with `JAVA_HOME` defaulting to `/usr/lib/jvm/default-jvm`).
+The Roundup Action uses the [NASA-PDS](https://github.com/NASA-PDS) [Github Actions Base](https://github.com/NASA-PDS/github-actions-base) as its starting environment. As of the time of this writing, this is [Alpine Linux 3.16](https://www.alpinelinux.org), [Python 3.9.16](https://www.python.org/), [npm 8.10.0](https://www.npmjs.com/) and [Apache Maven 3.8.5](https://maven.apache.org/), which in turns gives you [OpenJDK 17.0.10_p7](https://openjdk.java.net/) (with `JAVA_HOME` defaulting to `/usr/lib/jvm/default-jvm`).
 
 If you need a newer or older Java, or any other packages present in order to complete the unit tests, build, documentation, etc., steps of your roundup, you can use the `packages` variable to specify additional [Alpine Linux Packages](https://pkgs.alpinelinux.org/packages) that will be installed prior to starting. For example:
 
@@ -45,7 +46,7 @@ This causes the Roundup to use OpenJDK 11 and also installs the `pdfgrep` packag
 
 #### ☕️ Java Note
 
-If you install a JDK older than OpenJDK 1.8.0_252, you may need to also set the `JAVA_HOME` environment variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
+If you install a JDK older than OpenJDK 17.0.10_p7, you may need to also set the `JAVA_HOME` environment variable, as the default `/usr/lib/jvm/default-jvm` will point to the newest.
 
 
 ### 👮‍♂️ GitHub Admin Token
@@ -79,11 +80,11 @@ You can now (and _should_) destroy any saved copies of the token's hex string.
 
 ### 🔑 Code Signing Key
 
-Signing code artifacts helps ensure that the code is not just created by who we say created it but that it's unmodified and free from inserted hacks like trojans or viruses. (Of course, it says nothing about the code's _quality_, which may be questionable or could itself _be_ a trojan or virus.) The Roundup uses the code signing key to automatically make these assertions by signing code artifacts it sends to the [OSSRH](https://central.sonatype.org/pages/ossrh-guide.html) (in the future, we could also sign Python artifacts sent to the [PyPI](https://pypi.org/)).
+Signing code artifacts helps ensure that the code is not just created by who we say created it but that it's unmodified and free from inserted hacks like trojans or viruses. (Of course, it says nothing about the code's _quality_, which may be questionable or could itself _be_ a trojan or virus.) The Roundup uses the code signing key to automatically make these assertions by signing code artifacts it sends to the [OSSRH](https://central.sonatype.org/pages/ossrh-guide.html) (in the future, we could also sign Python artifacts sent to the [PyPI](https://pypi.org/)) or [npmjs.com](https://www.npmjs.com/).
 
 The [NASA-PDS](https://github.com/NASA-PDS) organization includes a `CODE_SIGNING_KEY` that all repositories within it inherit.
 
-**📒 Note:** Whether _automatically signing artifacts_ is a safe practice is left for future discussion! 😩
+**📒 Note:** Whether _automatically signing artifacts_ is a safe practice is left for future discussion! 🤔
 
 To set up a your own code signing key for the Roundup action, first create an OpenPGP-compatible key pair using ``gpg`` or similar tool; for example, with [GnuPG 2.2](https://www.gnupg.org/), run ``gpg --full-generate-key``:
 
@@ -108,8 +109,8 @@ This puts the encoded private key onto your pasteboard, ready for pasting into G
 
 There are several different flavors of roundups that you can specify `with` the `assembly` parameter in your workflow. The flavor of assembly tells if you're doing a stable versus an unstable software release and what steps of the roundup to perform. They are as follows:
 
--   `stable` — this is the "standard" PDS assembly for stable software releases. It does the steps of unit testing, integration testing, documentation generation, software building, artifact publication, requirements generation, changelog generation, GitHub releasing, and documentation publication. Because it's a "stable" assembly, it sends all this to production servers; that means non-SNAPSHOT releases to OSSRH for Maven artifacts, the production PyPI for Python artifacts, etc.
--   `unstable` — this is the same as the `stable` PDS assembly but for unstable software releases. It does all the same steps as the stable assembly, but OSSRH artifacts are marked as `SNAPSHOT`s, the `test.pypi.org` is used instead of `pypi.org`, etc. This is the default if you don't specify an assembly.
+-   `stable` — this is the "standard" PDS assembly for stable software releases. It does the steps of unit testing, integration testing, documentation generation, software building, artifact publication, requirements generation, changelog generation, GitHub releasing, and documentation publication. Because it's a "stable" assembly, it sends all this to production servers; that means non-SNAPSHOT releases to OSSRH for Maven artifacts, the production PyPI for Python artifacts, or just sends the release to npmjs.com (which differentiates stable versus unstable with a suffix on the version number).
+-   `unstable` — this is the same as the `stable` PDS assembly but for unstable software releases. It does all the same steps as the stable assembly, but OSSRH artifacts are marked as `SNAPSHOT`s, the `test.pypi.org` is used instead of `pypi.org`, or a version like `1.2.3-unstable` for npm.js artifacts. This is the default if you don't specify an assembly.
 -   `integration` — this is the same as the `unstable` PDS assembly, but omits the requirements generation and changelog generation steps.
 -   `noop` — this is an assembly that does nothing, i.e., "no operation".
 -   `env` — this is an assembly whose steps are defined by environment variables:
@@ -119,7 +120,7 @@ There are several different flavors of roundups that you can specify `with` the 
 
 ### 🛫 Releases
 
-The Roundup includes built-in support to make official releases of software, publishing artifacts to well-known repositories, and including release archives on GitHub. The [PDS Java Template Repository](https://github.com/NASA-PDS/pds-template-repo-java) (historically called the "generic template") and the [PDS Python Template Repository](https://github.com/NASA-PDS/pds-template-repo-python) (historically called the Python template) have the correct GitHub Actions workflows to support this. If you create a new PDS repository from those templates, you're all set to roundup! Yee-haw!
+The Roundup includes built-in support to make official releases of software, publishing artifacts to well-known repositories, and including release archives on GitHub. The [PDS Java Template Repository](https://github.com/NASA-PDS/pds-template-repo-java) (historically called the "generic template") and the [PDS Python Template Repository](https://github.com/NASA-PDS/pds-template-repo-python) (historically called the Python template) have the correct GitHub Actions workflows to support this. So does the [Node.js template](https://github.com/NASA-PDS/template-repo-nodejs). If you create a new PDS repository from those templates, you're all set to roundup! Yee-haw!
 
 To make an offical release of software version `VERSION`, create a tag called `release/VERSION` and push it to GitHub. For example, to release version 2.1.0 of your software based on the latest `main`:
 ```console

--- a/src/pds/roundup/_nodejs.py
+++ b/src/pds/roundup/_nodejs.py
@@ -1,0 +1,295 @@
+# encoding: utf-8
+
+'''PDS Roundup: Node.js context'''
+
+from .context import Context
+from .errors import RoundupError, InvokedProcessError
+from .step import Step, StepName, NullStep, RequirementsStep, DocPublicationStep, ChangeLogStep as BaseChangeLogStep
+from .util import git_config, invoke, invokeGIT, TAG_RE, add_version_label_to_open_bugs, commit, delete_tags
+import shutil, logging, os, json, re
+
+_logger = logging.getLogger(__name__)
+
+
+class NodeJSContext(Context):
+    '''A Node.js context supports Node.js software proejcts'''
+    def __init__(self, cwd, environ, args):
+        self.steps = {
+            StepName.artifactPublication: _ArtifactPublicationStep,
+            StepName.build:               _BuildStep,
+            StepName.changeLog:           ChangeLogStep,
+            StepName.cleanup:             _CleanupStep,
+            StepName.docPublication:      _DocPublicationStep,
+            StepName.docs:                _DocsStep,
+            StepName.githubRelease:       _GitHubReleaseStep,
+            StepName.integrationTest:     _IntegrationTestStep,
+            StepName.null:                NullStep,
+            StepName.preparation:         _PreparationStep,
+            StepName.requirements:        RequirementsStep,
+            StepName.unitTest:            _UnitTestStep,
+            StepName.versionBump:         _VersionBumpingStep,
+            StepName.versionCommit:       _VersionCommittingStep,
+        }
+        super().__init__(cwd, environ, args)
+
+
+class _NodeJSStep(Step):
+    '''A Node.js-specific step.'''
+
+    # A version regular expression adhereing to npm's strict semver policy
+    semver_re = re.compile(r'^(\d+)\.(\d+)\.(\d+)-unstable')
+
+    def read_package_metadata(self):
+        '''Read the package.json file and yield its contents as a dict.'''
+        _logger.debug('Getting package metdadata from package.json')
+        try:
+            with open('package.json', 'r') as package_json_io:
+                return json.load(package_json_io)
+        except IOError as ex:
+            _logger.exception('Failed to read package.json: %s', str(ex))
+            raise RoundupError(ex)
+
+    def write_version_number(self, version_number):
+        '''Write the new ``version_number`` to the ``package.json`` file.'''
+        _logger.debug('Finding version in package.json')
+        try:
+            metadata = self.read_package_metadata()
+            metadata['version'] = version_number
+            with open('package.json', 'w') as package_json_io:
+                _logger.debug('Writing package.json with new version %s', version_number)
+                json.dump(metadata, package_json_io, sort_keys=True, indent=4)
+        except IOError as ex:
+            _logger.exception('Failed to update package.json with new version %s: %s', version_number, str(ex))
+            raise RoundupError(ex)
+
+
+class _PreparationStep(_NodeJSStep):
+    '''Prepare the python repository for action.'''
+    def _make_npmrc(self):
+        token = os.getenv('NPMJS_COM_TOKEN')
+        if not token:
+            raise RoundupError('💣 No NPMJS_COM_TOKEN in environment; cannot do anything; aborting')
+
+        # home_dir = '/root' if os.getenv('GITHUB_ACTIONS', 'true') == 'true' else os.getenv('HOME')
+        # with open(os.path.join(home_dir, '.npmrc'), 'w') as npmrc:
+        with open('.npmrc', 'w') as npmrc:
+            npmrc.write(f'''@nasapds:registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken={token}
+email=pdsen-ci@jpl.nasa.gov
+
+npmScopes:
+ nasapds:
+   npmAlwaysAuth: true
+   npmRegistryServer: "https://registry.npmjs.org/"
+   npmAuthToken: {token}
+//registry.npmjs.org/:_authToken={token}
+            ''')
+
+    def execute(self):
+        _logger.debug('Node.js preparation step')
+        git_config()
+        self._make_npmrc()
+
+        # In github-actions-base, Node.js executables get installed in ~root/node_modules/.bin,
+        # so make sure that's on our PATH
+        os.environ['PATH'] = f'/root/node_modules/.bin:{os.environ["PATH"]}'
+
+        # Clean up any node_modules from earlier—if any
+        shutil.rmtree('node_modules', ignore_errors=True)
+
+        # Install our Node.js package
+        invoke(['npm', 'install'])
+
+        # ☑️ TODO: what other prep steps are there?
+
+
+class _UnitTestStep(_NodeJSStep):
+    '''Unit test step, bruh.'''
+    def execute(self):
+        _logger.debug('Node.js unit test step')
+        invoke(['npm', 'test'])
+
+
+class _IntegrationTestStep(_NodeJSStep):
+    '''A step to take for integration tests with Node.js; what actually happens here is yet
+    to be determined.
+    '''
+    def execute(self):
+        _logger.debug('Node.js integration test step; TBD')
+
+
+class _DocsStep(_NodeJSStep):
+    '''A step that uses JSDoc (invoked by ``npm docs``) to generate documentation'''
+    def execute(self):
+        invoke(['npm', 'run', 'jsdoc'])
+
+
+class _VersionBumpingStep(_NodeJSStep):
+    '''Bump the version but do not commit it (yet).'''
+    def execute(self):
+        if not self.assembly.isStable():
+            _logger.debug('Skipping version bump for unstable build')
+            return
+
+        # Figure out the tag name; we use ``--tags`` to pick up all tags, not just the annotated
+        # ones. This'll help reduce erros by users who forget to annotate (``-a`` or ``--annoate``)
+        # their tags. The ``--abbrev 0`` truncates any post-tag commits
+        tag = invokeGIT(['describe', '--tags', '--abbrev=0', '--match', 'release/*']).strip()
+
+        if not tag:
+            raise RoundupError('🕊 Cannot determine the release tag; version bump failed')
+
+        match = TAG_RE.match(tag)
+        if not match:
+            raise RoundupError(f'🐎 Stable tag of «{tag}» but not a ``release/`` tag')
+
+        major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
+        full_version = f'{major}.{minor}.{micro}'
+        _logger.debug('🔖 So we got version %s', full_version)
+
+        if micro is None:
+            raise RoundupError('Invalid release version supplied in tag name. You must supply Major.Minor.Micro')
+
+        add_version_label_to_open_bugs(full_version)
+        self.write_version_number(full_version)
+
+
+class _VersionCommittingStep(_NodeJSStep):
+    '''Commit the bumped version.'''
+    def execute(self):
+        if not self.assembly.isStable():
+            _logger.debug('Skipping version commit for unstable build')
+            return
+        commit('package.json', 'Commiting package.json for stable release')
+
+
+class _BuildStep(_NodeJSStep):
+    '''A step that makes an installable package.'''
+    def execute(self):
+        if self.assembly.isStable():
+            # The package.json should already have the "stable" version number from the _VersionBumpingStep
+            # so we can just invoke ``npm build``
+            invoke(['npm', 'run', 'build'])
+        else:
+            # EA says we should rewrite the version number with ``-unstable`` in it
+            metadata = self.read_package_metadata()
+            unstable_version = metadata['version'] + '-unstable'
+            self.write_version_number(unstable_version)
+            invoke(['npm', 'run', 'build'])
+
+
+class _GitHubReleaseStep(_NodeJSStep):
+    '''A step that releases software to GitHub
+    '''
+    def _pruneDev(self):
+        '''Get rid of any "dev" tags. Apparently we want to do this always; see
+        https://github.com/NASA-PDS/roundup-action/issues/32#issuecomment-776309904
+        '''
+        delete_tags('*dev*')
+
+    def _pruneReleaseTags(self):
+        '''Get rid of ``release/*`` tags.'''
+        delete_tags('release/*')
+
+    def _tagRelease(self):
+        '''Tag the current release using the v1.2.3-style tag based on the release/1.2.3-style tag.'''
+        _logger.debug('🏷 Tagging the release')
+        tag = invokeGIT(['describe', '--tags', '--abbrev=0', '--match', 'release/*']).strip()
+        if not tag:
+            _logger.debug('🕊 Cannot determine what tag we are currently on, so skipping re-tagging')
+            return
+        match = TAG_RE.match(tag)
+        if not match:
+            _logger.debug('🐎 Stable tag at «%s» but not a ``release/`` style tag, so skipping tagging', tag)
+            return
+        major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
+        _logger.debug('🔖 So we got version %d.%d.%s', major, minor, micro)
+        # roundup-action#90: we no longer bump the version number; just re-tag at the current HEAD
+        tag = f'v{major}.{minor}.{micro}'
+        _logger.debug('🆕 New tag will be %s', tag)
+        invokeGIT(['tag', '--annotate', '--force', '--message', f'Tag release {tag}', tag])
+        invokeGIT(['push', '--tags'])
+
+    def execute(self):
+        '''Execute the Node.js GitHub release step'''
+        _logger.debug('👣 Node.js GitHub release step')
+        token = self.getToken()
+        if not token:
+            _logger.info('🤷‍♀️ No GitHub administrative token; cannot release to GitHub')
+            return
+        self._pruneDev()
+        if self.assembly.isStable():
+            self._tagRelease()
+            invoke(['/usr/local/bin/nodejs-release', '--debug', '--token', token])
+        else:  # It's unstable release
+            invoke(['/usr/local/bin/nodejs-release', '--debug', '--snapshot', '--token', token])
+            self._pruneReleaseTags()
+
+
+class _ArtifactPublicationStep(_NodeJSStep):
+    '''A step that publishes artifacts to the npmjs.com'''
+    def execute(self):
+        try:
+            if self.assembly.isStable():
+                argv = ['npm', 'publish', '--verbose', '--access', 'public']
+            else:
+                # In NASA-PDS/devops#69 @jordanpadams pefers "beta" to "unstable". This was
+                # corroborated in our stand up meeting on 2024-03-05.
+                #
+                # Also, apparently there's no way to re-release an unstable package to npm.
+                # We have to bump the version number.
+
+                metadata = self.read_package_metadata()
+                match = self.semver_re.match(metadata['version'])
+                if not match:
+                    raise RoundupError(f'The version number {metadata["version"]} in package.json is malformed')
+                major, minor, micro = int(match.group(1)), int(match.group(2)), int(match.group(3)) + 1
+                self.write_version_number(f'{major}.{minor}.{micro}-unstable')
+                argv = ['npm', 'publish', '--verbose', '--access', 'public']
+                commit('package.json', f'Committing bumped version № {major}.{minor}.{micro} for unstable assembly')
+            invoke(argv)
+        except InvokedProcessError:
+            # For unstalbe releases, we ignore this
+            if self.assembly.isStable(): raise
+
+
+class _DocPublicationStep(DocPublicationStep):
+
+    default_documentation_dir = 'out'
+
+
+class _CleanupStep(_NodeJSStep):
+    '''Step that tidies up.'
+
+    At this point we're cleaing up so errors are not longer considered awful.
+    '''
+    def execute(self):
+        _logger.debug('Node.js cleanup step')
+        if not self.assembly.isStable():
+            _logger.debug('Skipping cleanup for unstable build')
+            return
+
+        # NASA-PDS/roundup-action#99: delete the release/X.Y.Z tag
+        tag = invokeGIT(['describe', '--tags', '--abbrev=0', '--match', 'release/*']).strip()
+        if not tag:
+            raise RoundupError('🏷 Cannot determine the release tag at cleanup step')
+        invokeGIT(['push', 'origin', f':{tag}'])
+
+        version = self.read_package_metadata()['version']
+        match = re.match(r'(\d+)\.(\d+)\.(\d+)', version)
+        if not match:
+            _logger.info(f'Expected Major.Minor.Micro version in package.json but got «{version}» but whatever')
+            return
+        # NASA-PDS/roundup-action#81: Jordan would prefer the ``minor`` version get bumped, not the ``micro`` version:
+        major, minor, micro = int(match.group(1)), int(match.group(2)) + 1, int(match.group(3))
+        new_version = f'{major}.{minor}.0'
+        _logger.debug('🔖 Setting version %s in package.json', new_version)
+        self.write_version_number(new_version)
+        commit('package.json', f'Setting next dev version to {major}.{minor}.{micro}')
+
+
+class ChangeLogStep(BaseChangeLogStep):
+    def execute(self):
+        _logger.debug('Node.js changelog step')
+        delete_tags('*dev*')
+        super().execute()

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -170,11 +170,14 @@ def contextFactories():
     # of a plain Python context.
     from ._python import PythonContext
     from ._maven import MavenContext
+    from ._nodejs import NodeJSContext
     return {
-        'setup.cfg':   PythonContext,
-        'setup.py':    PythonContext,
-        'pom.xml':     MavenContext,
-        'project.xml': MavenContext
+        'setup.cfg':         PythonContext,
+        'setup.py':          PythonContext,
+        'pom.xml':           MavenContext,
+        'project.xml':       MavenContext,
+        'package.json':      NodeJSContext,
+        'package-lock.json': NodeJSContext
     }
 
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this if you dare and you'll add support for "rounding up" PDS-style Node.js repositories that use the [PDS Node.js template](https://github.com/NASA-PDS/template-repo-nodejs).

## ⚙️ Test Data and/or Report

Check out the glorious progress of the sandbox's [test repository](https://github.com/nasa-pds-engineering-node/essence), notably:

- [One unstable release and two stable releases](https://github.com/nasa-pds-engineering-node/essence/releases) on the release page at GitHub
- [The released packages](https://www.npmjs.com/package/@nasapds/essence?activeTab=readme) on npmjs.com
- [The documentation page](https://nasa-pds-engineering-node.github.io/essence/) hosted by GitHub pages


## ♻️ Related Issues

- https://github.com/NASA-PDS/devops/issues/63
- https://github.com/NASA-PDS/devops/issues/64
