### PR TITLE
Fix for NASA-PDS/peppi#75: publication of Peppi API documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ LABEL "com.github.actions.name"="PDS Roundup"
 # ----------------------
 
 ENV PYTHONUNBUFFERED=1
+ENV lasso_releasers=1.0.1
+ENV lasso_requirements=1.0.0
+ENV lasso_issues=1.3.1
 
 
 # Image Details
@@ -22,10 +25,45 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR    /usr/src/roundup
 COPY       README.md CHANGELOG.md LICENSE.txt setup.cfg setup.py ./
 COPY       src/ ./src
-ENTRYPOINT ["/usr/local/bin/roundup"]
+ENTRYPOINT ["/usr/src/roundup-venv/bin/roundup"]
 
 RUN : &&\
-    pip install 'lasso.releasers~=1.0.0' 'lasso.requirements~=1.0.0' &&\
-    pip install 'lasso-issues~=1.3.1' &&\
-    pip install /usr/src/roundup &&\
+    : Set up each dependency in its own venv and symlink the bins into /usr/local/bin &&\
+    : &&\
+    : First up, lasso.releasers &&\
+    python3 -m venv /usr/src/rel &&\
+    /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} &&\
+    ln -s /usr/src/rel/bin/maven-release /usr/local/bin &&\
+    ln -s /usr/src/rel/bin/nodejs-release /usr/local/bin &&\
+    ln -s /usr/src/rel/bin/python-release /usr/local/bin &&\
+    ln -s /usr/src/rel/bin/snapshot-release /usr/local/bin &&\
+    : &&\
+    : Next, lasso.requirements, which for some reason needs both an upgraded pip and &&\
+    : the packaging package too &&\
+    python3 -m venv /usr/src/req &&\
+    /usr/src/req/bin/pip install --quiet --upgrade pip &&\
+    : Do not upgrade packaging past v20 as requirement-report 1.0.0 does not work with newer versions &&\
+    : And YES, lasso.requirements should declare its own dependencies &&\
+    /usr/src/req/bin/pip install --quiet packaging~=20.9 &&\
+    /usr/src/req/bin/pip install --quiet lasso.requirements~=${lasso_requirements} &&\
+    ln -s /usr/src/req/bin/requirement-report /usr/local/bin &&\
+    : &&\
+    : Now lasso.issues &&\
+    python3 -m venv /usr/src/iss &&\
+    /usr/src/iss/bin/pip install --quiet lasso.issues~=${lasso_issues} &&\
+    ln -s /usr/src/iss/bin/add-version-label-to-open-bugs /usr/local/bin &&\
+    ln -s /usr/src/iss/bin/milestones /usr/local/bin &&\
+    ln -s /usr/src/iss/bin/move-issues /usr/local/bin &&\
+    ln -s /usr/src/iss/bin/pds-issues /usr/local/bin &&\
+    ln -s /usr/src/iss/bin/pds-labels /usr/local/bin &&\
+    : &&\
+    : Now twine which must be version 6.0.1 since older ones do not work with PyPI and newer ones are buggy &&\
+    python3 -m venv /usr/src/twine &&\
+    /usr/src/twine/bin/pip install --quiet twine==6.0.1 &&\
+    rm -f /usr/local/bin/twine &&\
+    ln -s /usr/src/twine/bin/twine /usr/local/bin &&\
+    : &&\
+    : Now install the Roundup Action &&\
+    python3 -m venv /usr/src/roundup-venv &&\
+    /usr/src/roundup-venv/bin/pip install --quiet /usr/src/roundup &&\
     :

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,27 +24,17 @@ packages = find_namespace:
 package_dir =
     =src
 
-# Note: the ``install_requires`` dependencies below must match certain
-# packages "baked into" the nasapds/github-actions-base which is used
-# by GitHub Actions to save time on spinning up the Roundup's container.
+# Note: the ``install_requires`` dependencies below without a version specification are
+# those that come from nasapds/github-actions-base which are "baked into" the image in order
+# to save time spinning up the Roundup's container.
 
 install_requires =
-    alabaster <=0.7.13
-    github3.py==1.3.0
-    lxml==4.6.3
-    packaging==21.0
-    requests==2.23.0
-    sphinx-rtd-theme~=0.5.0
-    sphinx-substitution-extensions==2020.9.30.0
-    sphinx==3.2.1
-    sphinxcontrib-applehelp==1.0.4
-    sphinxcontrib-devhelp==1.0.2
-    sphinxcontrib-htmlhelp==2.0.1
-    sphinxcontrib-jsmath==1.0.1
-    sphinxcontrib-qthelp==1.0.3
-    sphinxcontrib-serializinghtml==1.1.5
-    twine==3.4.2
-    wheel==0.40.0
+    alabaster<=0.7.13
+    github3.py
+    lxml
+    packaging
+    requests
+    wheel
 
 
 [options.package_data]

--- a/src/pds/roundup/_detectives.py
+++ b/src/pds/roundup/_detectives.py
@@ -1,0 +1,57 @@
+# encoding: utf-8
+#
+# Refactored from lasso.requirements to reduce coupling and dependency traffic jams
+
+import os.path, logging
+
+_logger = logging.getLogger(__name__)
+
+
+class VersionDetective(object):
+    '''🕵️‍♀️ Abstract detective for a version of a Python package given its source code.'''
+
+    def __init__(self, workspace: str):
+        self.workspace = workspace
+
+    def findfile(self, fn: str):
+        '''Utility method: Find the file named ``fn`` in the workspace and return its path.
+
+        Return None if it's not found. Handy for subclasses.
+        '''
+        path = os.path.join(self.workspace, fn)
+        return path if os.path.isfile(path) else None
+
+    def detect(self):
+        '''Detect the version of the Python package in the source code ``workspace`` and return it.
+
+        Return None if we can't figure it out.
+        '''
+        raise NotImplementedError("Subclasses must implement ``VersionDetective.detect``")
+
+
+class TextFileDetective(VersionDetective):
+    '''Detective that looks for a ``version.txt`` file of some kind for a version indication.'''
+
+    @classmethod
+    def locate_file(cls, root_dir):
+        src_dir = os.path.join(root_dir, "src")
+        if not os.path.isdir(src_dir):
+            raise ValueError("Unable to locate ./src directory in workspace.")
+
+        version_file = None
+        for dirpath, _dirnames, filenames in os.walk(src_dir):
+            for fn in filenames:
+                if fn.lower() == "version.txt":
+                    version_file = os.path.join(dirpath, fn)
+                    _logger.debug("🪄 Found a version.txt in %s", version_file)
+                    break
+
+        return version_file
+
+    def detect(self):
+        version_file = self.locate_file(self.workspace)
+        if version_file is not None:
+            with open(version_file, "r") as inp:
+                return inp.read().strip()
+        else:
+            return None


### PR DESCRIPTION
## 🗒️ Summary

Merge this in order to get Peppi's Sphinx-based documentation to publish—including its API documentation. Roundup Action will honor the Sphinx specified by a Python project but will fall back to the older version in [github-actions-base](https://github.com/NASA-PDS/github-actions-base/) if necessary.

This PR also updates the "Twine" uploader to 6.0.1 in order to remain compatible with upgrades taking place at `pypi.org` and `test.pypi.org` (but not to a _newer_ version of Twine which is [apparently buggy](https://github.com/pypi/warehouse/issues/15611)).

## ⚙️ Test Data and/or Report

- See [the Peppi website from the "sandbox"](https://nasa-pds-engineering-node.github.io/peppi/)
- See [the log of a successful "roundup"](https://github.com/nasa-pds-engineering-node/peppi/actions/runs/14136777841) that produced that website
- See [the published artifact](https://pypi.org/project/pds.notpeppi/) at the "cheese shop"

## ♻️ Related Issues

- [NASA-PDS/peppi#75](https://github.com/NASA-PDS/peppi/issues/75)