### PR TITLE
Discontinue open-bug labeling

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,9 +175,9 @@
         "filename": "src/pds/roundup/util.py",
         "hashed_secret": "2cdaeb7565d9036f422d87494886f0295a6e6cd3",
         "is_verified": false,
-        "line_number": 111
+        "line_number": 115
       }
     ]
   },
-  "generated_at": "2024-03-15T19:54:15Z"
+  "generated_at": "2025-05-05T19:04:23Z"
 }

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -44,12 +44,16 @@ def populateEnvVars(env):
 
 
 def add_version_label_to_open_bugs(version):
-    _logger.debug('Adding version label to open bugs')
-    owner, repo = os.getenv('GITHUB_REPOSITORY').split('/')
-    invoke([
-        'add-version-label-to-open-bugs', '--labelled-version', version,
-        '--token', os.getenv('ADMIN_GITHUB_TOKEN'), '--github-org', owner, '--github-repo', repo,
-    ])
+    _logger.info('Per NASA-PDS/roundup-action#145 we are no longer adding a version label to open bugs')
+    # The rest of this function is commented out for NASA-PDS/roundup-action#145; it remains
+    # for posterity:
+    #
+    # _logger.debug('Adding version label to open bugs')
+    # owner, repo = os.getenv('GITHUB_REPOSITORY').split('/')
+    # invoke([
+    #     'add-version-label-to-open-bugs', '--labelled-version', version,
+    #     '--token', os.getenv('ADMIN_GITHUB_TOKEN'), '--github-org', owner, '--github-repo', repo,
+    # ])
 
 
 def invoke(argv):


### PR DESCRIPTION
## 🗒️ Summary

In #145 we decided that the open bug labeling was getting out of hand; just see the screenshot in the issue.

Merge this and the open bug labeling ceases. Existing open bug labels will remain.

## ⚙️ Test Data and/or Report

Take a look at the [Epitome](https://github.com/nasa-pds-engineering-node/epitome/) project's [issues](https://github.com/nasa-pds-engineering-node/epitome/issues) in the sandbox. Note the two issues have the "open 3.8.0" label.

Those issues were open before modifying the Roundup Action. 

After modifying the Roundup Action, we then released [v3.9.0](https://github.com/nasa-pds-engineering-node/epitome/releases/tag/v3.9.0) of Epitome. Note that there is _no_ "open 3.9.0" label on the two issues.

## ♻️ Related Issues

- #145 
