### PR TITLE
Use new Maven Central Portal credentials instead of older OSSRH credentials

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -85,6 +85,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -139,7 +143,7 @@
         "filename": "README.md",
         "hashed_secret": "0ebdbaa404ab765b45b3af96c0e1874401ac3ef3",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 97
       }
     ],
     "action.yaml": [
@@ -179,5 +183,5 @@
       }
     ]
   },
-  "generated_at": "2025-05-05T19:04:23Z"
+  "generated_at": "2025-06-05T16:01:50Z"
 }

--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ Depending on the roundup, you may also need the following environment variables:
 
 -   `pypi_username` — Username to use when registering a Python package
 -   `pypi_password` — Password for `pypi_username`
--   `ossrh_username` — Username to use for uploading a snapshot [OSSRH](https://central.sonatype.org/pages/ossrh-guide.html) artifact
--   `ossrh_password` — Password for `ossrh_username`
+-   `central_portal_username` — Username to use for uploading artifacts to the [Maven Central Repository](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#authentication) 
+-   `central_portal_token` — The token that goes with the `central_portal_username`
 -   `NPMJS_COM_TOKEN` — Token for https://www.npmjs.com/ which must be a granular access token with read/write permission to the `@nasapds` scope
 -   `CODE_SIGNING_KEY` — GPG **private** key (base64 encoded) with which to sign artifacts
+
+📒 **Note:** We've migrated from using the Maven OSSRH to the new Maven Central Portal. The older variables, `ossrh_username` and `ossrh_password` no longer are used.
 
 
 ### 🍃 Environment
@@ -171,11 +173,11 @@ jobs:
                     packages: cowpoke,chili-sort,lasso
                 env:
                     ADMIN_GITHUB_TOKEN: ${{secrets.pat}}
-                    CODE_SIGNING_KEY:   ${{secrets.CODE_SIGNING_KEY}}
-                    ossrh_username:     jocowboy
-                    ossrh_password:     ${{secrets.OSSRH_PASSWORD}}
-                    pypi_username:      snakewrangler
-                    pypi_password:      ${{secrets.PYPI_PASSWORD}}
+                    CODE_SIGNING_KEY: ${{secrets.CODE_SIGNING_KEY}}
+                    central_portal_username: jocowboy
+                    central_portal_token: ${{secrets.CENTRAL_PORTAL_TOKEN}}
+                    pypi_username: snakewrangler
+                    pypi_password: ${{secrets.PYPI_PASSWORD}}
 ```
 
 
@@ -204,8 +206,8 @@ But you could also invoke it the way GitHub Actions does; for example:
         --env ADMIN_GITHUB_TOKEN=$(cat my-dev-token.txt) \
         --env pypi_username=joe_cowboy4life \
         --env pypi_password=s3cr3t \
-        --env ossrh_username=java_cowboy4life \
-        --env ossrh_password=m0rec0ff33 \
+        --env central_portal_username=java_cowboy4life \
+        --env central_portal_token=m0rec0ff33 \
         --env GITHUB_REPOSITORY=joecowboy/test-repo \
         --volume /Users/joe/Documents/Development/test-repo:"/github/workspace" \
         pds-roundup --debug --assembly unstable

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -105,8 +105,9 @@ class _PreparationStep(Step):
         _logger.info('✍️ Writing Maven settings to %s', settings)
 
         env, creds = self.assembly.context.environ, {}
-        for var in ('username', 'password'):
-            varName = 'ossrh_' + var
+
+        for var in ('username', 'token'):
+            varName = 'central_portal_' + var
             value = env.get(varName)
             if not value: raise MissingEnvVarError(varName)
             creds[var] = value

--- a/src/pds/roundup/util.py
+++ b/src/pds/roundup/util.py
@@ -24,17 +24,17 @@ def populateEnvVars(env):
     required by a roundup. Return a copy of this modified mapping. Note that we may also log
     some warning messages if certain expected variables are missing.
     '''
-    copy                   = dict(env)
-    pypi_username          = copy.get('pypi_username', 'pypi')
-    pypi_password          = copy.get('pypi_password', 'secret')
-    ossrh_username         = copy.get('ossrh_username', 'ossrh')
-    ossrh_password         = copy.get('ossrh_password', 'secret')
-    java_home              = copy.get('JAVA_HOME', '/usr/lib/jvm/default-jvm')
-    copy['pypi_username']  = pypi_username
-    copy['pypi_password']  = pypi_password
-    copy['ossrh_username'] = ossrh_username
-    copy['ossrh_password'] = ossrh_password
-    copy['JAVA_HOME']      = java_home
+    copy                            = dict(env)
+    pypi_username                   = copy.get('pypi_username', 'pypi')
+    pypi_password                   = copy.get('pypi_password', 'secret')
+    central_portal_username         = copy.get('central_portal_username', 'ossrh')
+    central_portal_token            = copy.get('central_portal_token', 'secret')
+    java_home                       = copy.get('JAVA_HOME', '/usr/lib/jvm/default-jvm')
+    copy['pypi_username']           = pypi_username
+    copy['pypi_password']           = pypi_password
+    copy['central_portal_username'] = central_portal_username
+    copy['central_portal_token']    = central_portal_token
+    copy['JAVA_HOME']               = java_home
 
     for var in ('GITHUB_REPOSITORY',):  # List other important vars here
         if var not in env:


### PR DESCRIPTION
## 🗒️ Summary

Merge this to have the roundup use the new [Maven Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/) credentials instead of the older credentials for the OSSRH. This essentially changes all occurrences of `ossrh_username` to `central_portal_username` and `ossrh_password` to `central_portal_token`. 

Workflow YAML files that use the Roundup Action will also need to update their `environment` sections.

This is in response to OSSRH is reaching end-of-life](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration) on 2025-06-30.

This should be merged after the [namespace is migrated to the Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration).

## ⚙️ Test Data and/or Report

Not possible to test without actually migrating a project to use [the new PDS parent POM](https://github.com/NASA-PDS/pdsen-maven-parent/pull/66) and then attempting to do either a SNAPSHOT or a full release.


## ♻️ Related Issues

- https://github.com/NASA-PDS/software-issues-repo/issues/128
- https://github.com/NASA-PDS/software-issues-repo/issues/132
