### PR TITLE
Use correct key to refer to token

### DIFF
--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -128,7 +128,7 @@ class _PreparationStep(Step):
         servers.append(server)
         etree.SubElement(server, prefix + 'id').text = 'ossrh'
         etree.SubElement(server, prefix + 'username').text = creds['username']
-        etree.SubElement(server, prefix + 'password').text = creds['password']
+        etree.SubElement(server, prefix + 'password').text = creds['token']
         profiles = etree.Element(prefix + 'profiles')
         root.append(profiles)
         profile = etree.Element(prefix + 'profile')


### PR DESCRIPTION
## 🗒️ Summary

When setting up the Roundup's own `~/.m2/settings.xml` file, it was erroneously referring to the token as `password`, when it's `token` in its dictionary. (Of course, in the `settings.xml` file itself, it's still confusingly called `password`.)

## ⚙️ Test Data and/or Report

Untested. Maybe we should try this in the sandbox?


## ♻️ Related Issues

@al-niessner's `validate` run https://github.com/NASA-PDS/validate/actions/runs/15762934033 revealed this.