### PR TITLE
Upgrade to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # 🤠 PDS Engineering: Roundup
 # ============================
 
-FROM nasapds/github-actions-base:stable
+# Note: the github-actions-base image's `stable` tag should eventually be
+# on Python 3.13, but for now the image tagged `python3.13` will do fine.
+
+FROM nasapds/github-actions-base:python3.13
 
 
 # Metadata
@@ -31,37 +34,37 @@ RUN : &&\
     : Set up each dependency in its own venv and symlink the bins into /usr/local/bin &&\
     : &&\
     : First up, lasso.releasers &&\
-    python3 -m venv /usr/src/rel &&\
-    /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} &&\
+    python3 -m venv --system-site-packages /usr/src/rel &&\
+    : Normally we would use lasso.releasers~=${lasso_releasers} but we are transitioning Python 3.13 &&\
+    : should be → /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} ← &&\
+    : so do this for now: &&\
+    /usr/src/rel/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-releasers.git@python3.13 &&\
     ln -s /usr/src/rel/bin/maven-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/nodejs-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/python-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/snapshot-release /usr/local/bin &&\
     : &&\
-    : Next, lasso.requirements, which for some reason needs both an upgraded pip and &&\
-    : the packaging package too &&\
+    : Next, lasso.requirements, which for some reason needs an upgraded pip AND ALSO cannot use system-site-packages &&\
+    : because Sphinx 8.2.3 in the base image requires packaging ≥ 23.0 and lasso-requirements needs packaging ≅ 20.9 &&\
     python3 -m venv /usr/src/req &&\
     /usr/src/req/bin/pip install --quiet --upgrade pip &&\
-    : Do not upgrade packaging past v20 as requirement-report 1.0.0 does not work with newer versions &&\
-    : And YES, lasso.requirements should declare its own dependencies &&\
-    /usr/src/req/bin/pip install --quiet packaging~=20.9 &&\
-    /usr/src/req/bin/pip install --quiet lasso.requirements~=${lasso_requirements} &&\
+    : Normally we would use lasso-requirements~=${lasso_requirements} but we are transitioning Python 3.13 &&\
+    : should be → /usr/src/req/bin/pip install --quiet lasso-requirements~=${lasso_requirements} ← &&\
+    : so do this for now: &&\
+    /usr/src/req/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-requirements.git@python3.13 &&\
     ln -s /usr/src/req/bin/requirement-report /usr/local/bin &&\
     : &&\
     : Now lasso.issues &&\
     python3 -m venv /usr/src/iss &&\
-    /usr/src/iss/bin/pip install --quiet lasso.issues~=${lasso_issues} &&\
+    : Normally we would use lasso.issues~=${lasso_issues} but we are transitioning Python 3.13 &&\
+    : should be → /usr/src/iss/bin/pip install --quiet lasso.issues~=${lasso_issues} ← &&\
+    : so do this for now: &&\
+    /usr/src/iss/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-issues.git@python3.13 &&\
     ln -s /usr/src/iss/bin/add-version-label-to-open-bugs /usr/local/bin &&\
     ln -s /usr/src/iss/bin/milestones /usr/local/bin &&\
     ln -s /usr/src/iss/bin/move-issues /usr/local/bin &&\
     ln -s /usr/src/iss/bin/pds-issues /usr/local/bin &&\
     ln -s /usr/src/iss/bin/pds-labels /usr/local/bin &&\
-    : &&\
-    : Now twine which must be version 6.0.1 since older ones do not work with PyPI and newer ones are buggy &&\
-    python3 -m venv /usr/src/twine &&\
-    /usr/src/twine/bin/pip install --quiet twine==6.0.1 &&\
-    rm -f /usr/local/bin/twine &&\
-    ln -s /usr/src/twine/bin/twine /usr/local/bin &&\
     : &&\
     : Now install the Roundup Action &&\
     python3 -m venv /usr/src/roundup-venv &&\

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     lxml
     packaging
     requests
+    twine
     wheel
 
 

--- a/src/pds/__init__.py
+++ b/src/pds/__init__.py
@@ -1,5 +1,3 @@
 # encoding: utf-8
 
 '''PDS namespace'''
-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/src/pds/roundup/__init__.py
+++ b/src/pds/roundup/__init__.py
@@ -2,7 +2,7 @@
 
 '''🤠 PDS Roundup: Continuous Integration and Development'''
 
-import pkg_resources
+import importlib.resources
 
 
 def _read_version():
@@ -11,7 +11,7 @@ def _read_version():
     cannot contain any extra comments and we assume it's text witn bytes encoded in
     utf-8.
     '''
-    return pkg_resources.resource_string(__name__, 'VERSION.txt').decode('utf-8').strip()
+    return importlib.resources.files(__name__).joinpath("VERSION.txt").read_text().strip()
 
 
 __version__ = VERSION = _read_version()

--- a/src/pds/roundup/_python.py
+++ b/src/pds/roundup/_python.py
@@ -82,7 +82,7 @@ class _UnitTestStep(_PythonStep):
         tox = os.path.abspath(os.path.join(self.assembly.context.cwd, 'venv', 'bin', 'tox'))
         if os.path.isfile(tox):
             _logger.debug('Trying the new way: ``tox``')
-            invoke([tox, '-e', 'py39'])  # ``py39`` = unit tests
+            invoke([tox])
         else:
             _logger.debug('Trying the old way: ``setup.py test``')
             invoke(['python', 'setup.py', 'test'])
@@ -103,8 +103,13 @@ class _DocsStep(_PythonStep):
             _logger.info('🫣  About to do `/github/workspace/venv/bin/sphinx-build`')
             invoke(['/github/workspace/venv/bin/sphinx-build', '--version'])
             invoke(['/github/workspace/venv/bin/sphinx-build', '-a', '-b', 'html', 'docs/source', 'docs/build'])
-        except InvokedProcessError as ex:
-            _logger.info('🫣  Got an InvokedProcessError %r, so doing /usr/local/bin/sphinx-build', ex)
+        except (InvokedProcessError, FileNotFoundError) as ex:
+            # For some reason, my test repo install a sphinx-build (and all its brethren) in the venv,
+            # but not under the Roundup Action
+            _logger.info('🫣  Got a %r error, so doing /usr/local/bin/sphinx-build', ex)
+            _logger.info('🥸 by the way here is what is in the venv bin')
+            invoke(['ls', '-l', '/github/workspace/venv/bin'])
+            _logger.info('🥸 GOT THAT? Now onto /usr/local/bin/sphinx-build')
             try:
                 invoke(['/usr/local/bin/sphinx-build', '--version'])
                 invoke(['/usr/local/bin/sphinx-build', '-a', '-b', 'html', 'docs/source', 'docs/build'])


### PR DESCRIPTION
## 🗒️ Summary

Merge this to transition to Python 3.13.

👉 **Note:** This is an _interim_ step in order to get the Roundup Action live in the main NASA-PDS organization. You'll note that it refers to certain repositories and Docker images with a `python3.13` tag. Once the pull requests for those other repositories are merged, we can change this to use PyPI-released packages and the `:stable` tag for the base Docker image.

## ⚙️ Test Data and/or Report

See successful Roundup runs at

- Stable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/16601184002
- Unstable: https://github.com/nasa-pds-engineering-node/epitome/actions/runs/14842393866

## ♻️ Related Issues

- https://github.com/NASA-PDS/template-repo-python/issues/105
