### PR TITLE
Complete 3.13 transition; upgrade lasso.releasers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ LABEL "com.github.actions.name"="PDS Roundup"
 # ----------------------
 
 ENV PYTHONUNBUFFERED=1
-ENV lasso_releasers=1.0.1
-ENV lasso_requirements=1.0.0
-ENV lasso_issues=1.3.1
+ENV lasso_releasers=1.2.0
+ENV lasso_requirements=1.1.0
+ENV lasso_issues=1.4.0
 
 
 # Image Details
@@ -35,10 +35,7 @@ RUN : &&\
     : &&\
     : First up, lasso.releasers &&\
     python3 -m venv --system-site-packages /usr/src/rel &&\
-    : Normally we would use lasso.releasers~=${lasso_releasers} but we are transitioning Python 3.13 &&\
-    : should be → /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} ← &&\
-    : so do this for now: &&\
-    /usr/src/rel/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-releasers.git@python3.13 &&\
+    /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} &&\
     ln -s /usr/src/rel/bin/maven-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/nodejs-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/python-release /usr/local/bin &&\
@@ -48,17 +45,13 @@ RUN : &&\
     : because Sphinx 8.2.3 in the base image requires packaging ≥ 23.0 and lasso-requirements needs packaging ≅ 20.9 &&\
     python3 -m venv /usr/src/req &&\
     /usr/src/req/bin/pip install --quiet --upgrade pip &&\
-    : Normally we would use lasso-requirements~=${lasso_requirements} but we are transitioning Python 3.13 &&\
-    : should be → /usr/src/req/bin/pip install --quiet lasso-requirements~=${lasso_requirements} ← &&\
-    : so do this for now: &&\
+    /usr/src/req/bin/pip install --quiet lasso-requirements~=${lasso_requirements} &&\
     /usr/src/req/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-requirements.git@python3.13 &&\
     ln -s /usr/src/req/bin/requirement-report /usr/local/bin &&\
     : &&\
     : Now lasso.issues &&\
     python3 -m venv /usr/src/iss &&\
-    : Normally we would use lasso.issues~=${lasso_issues} but we are transitioning Python 3.13 &&\
-    : should be → /usr/src/iss/bin/pip install --quiet lasso.issues~=${lasso_issues} ← &&\
-    : so do this for now: &&\
+    /usr/src/iss/bin/pip install --quiet lasso.issues~=${lasso_issues} &&\
     /usr/src/iss/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-issues.git@python3.13 &&\
     ln -s /usr/src/iss/bin/add-version-label-to-open-bugs /usr/local/bin &&\
     ln -s /usr/src/iss/bin/milestones /usr/local/bin &&\


### PR DESCRIPTION
## 🗒️ Summary

The Roundup Action depends on several external programs the PDS has developed to do its job:

- [lasso-releasers](https://github.com/NASA-PDS/lasso-releasers)
- [lasso-requirements](https://github.com/NASA-PDS/lasso-requirements)
- [lasso-issues](https://github.com/NASA-PDS/lasso-issues)

Since we started the Python 3.13 transition, it's been installing these in its Dockerfile using `pip install` with `git+https://…@python3.13`-style URLs. **Merge this to use official release on PyPI** instead.

It also **upgrades lasso-releasers to a newly-released version**, [which fixes several issues in dealing with Maven releases](https://github.com/NASA-PDS/lasso-releasers/pull/4).

## ⚙️ Test Data and/or Report

See [this successful Roudnup Action run](https://github.com/NASA-PDS/lasso-releasers/actions/runs/17807653669).

See also this successful build of the action's image:
```
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 2.64kB done
#1 DONE 0.0s

#2 [internal] load metadata for docker.io/nasapds/github-actions-base:python3.13
#2 DONE 0.0s

#3 [internal] load .dockerignore
#3 transferring context: 156B done
#3 DONE 0.0s

#4 [1/5] FROM docker.io/nasapds/github-actions-base:python3.13
#4 DONE 0.0s
…
#10 exporting to image
#10 exporting layers
#10 exporting layers 1.1s done
#10 writing image sha256:1680bb082e09ea63ee3cf2ddb9523d8c0e0c0439e7fb76a928732f25de771fb8
#10 writing image sha256:1680bb082e09ea63ee3cf2ddb9523d8c0e0c0439e7fb76a928732f25de771fb8 done
…
#10 DONE 1.1s
```

## ♻️ Related Issues

This all started [on Slack](https://jpl.slack.com/archives/GCGR1R3A4/p1758067039449149).