### PR TITLE
Resolve #155: source archives and tagged trees have corrected <version> in pom.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ RUN : &&\
     : &&\
     : First up, lasso.releasers &&\
     python3 -m venv --system-site-packages /usr/src/rel &&\
-    /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} &&\
+    : For roundup-action 155, commenting this out and installing from github &&\
+    : /usr/src/rel/bin/pip install --quiet lasso.releasers~=${lasso_releasers} &&\
+    /usr/src/rel/bin/pip install --quiet git+https://github.com/NASA-pds/lasso-releasers.git@roundup-action-155 &&\
     ln -s /usr/src/rel/bin/maven-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/nodejs-release /usr/local/bin &&\
     ln -s /usr/src/rel/bin/python-release /usr/local/bin &&\

--- a/src/pds/roundup/_maven.py
+++ b/src/pds/roundup/_maven.py
@@ -223,8 +223,10 @@ class _GitHubReleaseStep(_MavenStep):
         major, minor, micro = int(match.group(1)), int(match.group(2)), match.group(4)
         _logger.debug('🔖 So we got version %d.%d.%s', major, minor, micro)
         # roundup-action#90: we no longer bump the version number; just re-tag at the current HEAD
-        tag = f'v{major}.{minor}.{micro}'
-        _logger.debug('🆕 New tag will be %s', tag)
+        tag, pom_version = f'v{major}.{minor}.{micro}', f'{major}.{minor}.{micro}'
+        _logger.debug('🆕 New GitHub tag will be %s and pom version will be %s', tag, pom_version)
+        self.invokeMaven(['-DgenerateBackupPoms=false', f'-DnewVersion={major}.{minor}.{micro}', 'versions:set'])
+        self.commit_poms(f'Stable release {pom_version} in poms')
         invokeGIT(['tag', '--annotate', '--force', '--message', f'Tag release {tag}', tag])
         invokeGIT(['push', '--tags'])
 


### PR DESCRIPTION
## 🗒️ Summary

Merge this to fix the problem when the Roundup Action was creating release pages with source `.tar.gz` and source `.zip` file artifacts as well as tagged trees with the previous version as `-SNAPSHOT` in `pom.xml`.

For example, if you did

    git tag --message release/1.2.0 release/1.2.0 && git push origin release/1.2.0

everything would seem to work. If you then visited the "Release" page for your repository, under "Release 1.2.0", if you downloaded the "Source code (zip)" or "Source code (tar.gz)" files, the `pom.xml` file would have
```xml
<version>1.1.0-SNAPSHOT</version>
```
appearing in it. The same would apply if you did a `git checkout v1.2.0` and opened the `pom.xml` in this "detached HEAD" state.

This PR fixes it—so long as you also merge the matching PR in lasso-releasers.

## ⚙️ Test Data and/or Report

I ran in the [exemplar repository](https://github.com/nasa-pds-engineering-node/exemplar/):
```console
$ cd exemplar
$ git tag --message release/7.1.0 release/7.1.0
$ git push origin release/7.1.0
```
And the Roundup log completed.

I then download the Source code artifacts from the [release v7.1.0 page](https://github.com/nasa-pds-engineering-node/exemplar/releases/tag/v7.1.0):
```console
$ cd /tmp
$ curl --silent -L 'https://github.com/nasa-pds-engineering-node/exemplar/archive/refs/tags/v7.1.0.tar.gz' | tar xzf -
$ egrep 'version>7' exemplar-7.1.0/pom.xml
    <version>7.1.0</version>
$ rm -rf exemplar-7.1.0
$ curl --silent -LO 'https://github.com/nasa-pds-engineering-node/exemplar/archive/refs/tags/v7.1.0.zip'
$ unzip -qq v7.1.0.zip
$ egrep 'version>7' exemplar-7.1.0/pom.xml 
    <version>7.1.0</version>
```
Finally I checked the `v7.1.0` tag:
```console
$ cd exemplar
$ git fetch
$ git checkout v7.1.0
$ egrep 'version>7' pom.xml 
    <version>7.1.0</version>
```

## ♻️ Related Issues

- #155 
